### PR TITLE
Bugfix/27 all atomicreadmodels gauge

### DIFF
--- a/Jarvis.Framework.Kernel/ProjectionEngine/Atomic/AtomicProjectionCheckpointManager.cs
+++ b/Jarvis.Framework.Kernel/ProjectionEngine/Atomic/AtomicProjectionCheckpointManager.cs
@@ -34,6 +34,7 @@ namespace Jarvis.Framework.Kernel.ProjectionEngine.Atomic
 #pragma warning disable S2971 // "IEnumerable" LINQs should be simplified
             var dictionary = _collection
                 .AsQueryable()
+                .Where(c => c.ReadmodelMissing == false)
                 .ToList()
                 .Select(_ => new KeyValuePair<String, AtomicProjectionCheckpoint>(_.Id, _));
 #pragma warning restore S2971 // "IEnumerable" LINQs should be simplified


### PR DESCRIPTION
_inMemoryCheckpoint concurrent dictionary should be populated with the "active" readmodels only