### PR TITLE
Feature/multi partition atomic readmodel live projection

### DIFF
--- a/Jarvis.Framework.Rebus/Jarvis.Framework.Rebus.csproj
+++ b/Jarvis.Framework.Rebus/Jarvis.Framework.Rebus.csproj
@@ -27,9 +27,9 @@
     <PackageReference Include="MongoDB.Driver.Core" Version="2.18.0" />
     <PackageReference Include="MongoDB.Driver.GridFS" Version="2.18.0" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.6.0" />
-    <PackageReference Include="NStore.Core" Version="0.13.1" />
-    <PackageReference Include="NStore.Domain" Version="0.13.1" />
-    <PackageReference Include="NStore.Persistence.Mongo" Version="0.13.1" />
+    <PackageReference Include="NStore.Core" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Domain" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Persistence.Mongo" Version="0.14.0-alpha.10" />
     <PackageReference Include="Rebus" Version="6.6.5" />
     <PackageReference Include="Rebus.Castle.Windsor" Version="6.0.0" />
     <PackageReference Include="Rebus.Events" Version="4.0.2" />

--- a/Jarvis.Framework.Shared/Helpers/MongoDriverHelper.cs
+++ b/Jarvis.Framework.Shared/Helpers/MongoDriverHelper.cs
@@ -14,6 +14,9 @@ using System.Threading.Tasks;
 
 namespace Jarvis.Framework.Shared.Helpers
 {
+    /// <summary>
+    /// Helper for MongoDrivers.
+    /// </summary>
     public static class MongoDriverHelper
     {
         public static void Drop<T>(this IMongoCollection<T> collection)

--- a/Jarvis.Framework.Shared/Jarvis.Framework.Shared.csproj
+++ b/Jarvis.Framework.Shared/Jarvis.Framework.Shared.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="MongoDB.Driver.Core" Version="2.18.0" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NStore.Core" Version="0.13.1" />
-    <PackageReference Include="NStore.Domain" Version="0.13.1" />
-    <PackageReference Include="NStore.Persistence.Mongo" Version="0.13.1" />
+    <PackageReference Include="NStore.Core" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Domain" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Persistence.Mongo" Version="0.14.0-alpha.10" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/Jarvis.Framework.Shared/ReadModel/Atomic/AbstractAtomicReadModel.cs
+++ b/Jarvis.Framework.Shared/ReadModel/Atomic/AbstractAtomicReadModel.cs
@@ -199,7 +199,8 @@ namespace Jarvis.Framework.Shared.ReadModel.Atomic
 		/// one event that is handled by the readmodel.
 		/// </summary>
 		/// <param name="changeset"></param>
-		/// <returns></returns>
+		/// <exception cref="JarvisFrameworkEngineException">if we dispatch a changeset in the past that was not dispatched
+		/// we have framework excepion.</exception>
 		public virtual Boolean ProcessChangeset(Changeset changeset)
 		{
 			Boolean processed = false;

--- a/Jarvis.Framework.Shared/ReadModel/Atomic/AbstractAtomicReadModel.cs
+++ b/Jarvis.Framework.Shared/ReadModel/Atomic/AbstractAtomicReadModel.cs
@@ -1,223 +1,277 @@
 ﻿using Fasterflect;
 using Jarvis.Framework.Shared.Events;
+using Jarvis.Framework.Shared.Exceptions;
+using Jarvis.Framework.Shared.Helpers;
 using MongoDB.Bson.Serialization.Attributes;
 using NStore.Domain;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Jarvis.Framework.Shared.ReadModel.Atomic
 {
-    /// <summary>
-    /// An abstract atomic readmodel is a readmodel that is 
-    /// capable to dispatch messages to give a view of a specific
-    /// aggregate. It is made to process only events of a single
-    /// aggregate.
-    /// </summary>
-    /// <typeparam name="TKey"></typeparam>
-#pragma warning disable S1210 // "Equals" and the comparison operators should be overridden when implementing "IComparable"
-    public abstract class AbstractAtomicReadModel :
-#pragma warning restore S1210 // "Equals" and the comparison operators should be overridden when implementing "IComparable"
-        IAtomicReadModel
-    {
-        protected AbstractAtomicReadModel(String id)
-        {
-            Id = id;
-        }
+	/// <summary>
+	/// An abstract atomic readmodel is a readmodel that is
+	/// capable to dispatch messages to give a view of a specific
+	/// aggregate. It is made to process only events of a single
+	/// aggregate.
+	/// </summary>
+	public abstract class AbstractAtomicReadModel : IAtomicReadModel
+	{
+		/// <summary>
+		/// Default constructor that will accept the id
+		/// </summary>
+		/// <param name="id"></param>
+		protected AbstractAtomicReadModel(String id)
+		{
+			Id = id;
+		}
 
-        /// <summary>
-        /// <para>
-        /// This is a shared function used to grab UserId from a <see cref="DomainEvent"/>, it can 
-        /// be changed statically by caller. It is static because there is no need to have a different
-        /// criteria for every readmodel. 
-        /// </para>
-        /// <para>
-        /// Basic implementation will use the <see cref="DomainEvent.IssuedBy"/> property and also
-        /// will remove domain name from the value.
-        /// </para>
-        /// </summary>
-        public static Func<DomainEvent, String> UserNameExtractor { get; set; } = InnerUserNameExtractor;
+		/// <summary>
+		/// <para>
+		/// This is a shared function used to grab UserId from a <see cref="DomainEvent"/>, it can
+		/// be changed statically by caller. It is static because there is no need to have a different
+		/// criteria for every readmodel.
+		/// </para>
+		/// <para>
+		/// Basic implementation will use the <see cref="DomainEvent.IssuedBy"/> property and also
+		/// will remove domain name from the value.
+		/// </para>
+		/// </summary>
+		public static Func<DomainEvent, String> UserNameExtractor { get; set; } = InnerUserNameExtractor;
 
-        private static string InnerUserNameExtractor(DomainEvent evt)
-        {
-            if (evt.IssuedBy != null)
-            {
-                if (evt.IssuedBy.Contains("\\"))
-                {
-                    return evt.IssuedBy.Split('\\').Last();
-                }
+		private static string InnerUserNameExtractor(DomainEvent evt)
+		{
+			if (evt.IssuedBy != null)
+			{
+				if (evt.IssuedBy.Contains("\\"))
+				{
+					return evt.IssuedBy.Split('\\').Last();
+				}
 
-                return evt.IssuedBy;
-            }
-            return null;
-        }
+				return evt.IssuedBy;
+			}
+			return null;
+		}
 
-        /// <summary>
-        /// Id of the aggregate
-        /// </summary>
-        public String Id { get; private set; }
+		/// <summary>
+		/// Id of the aggregate
+		/// </summary>
+		public String Id { get; private set; }
 
-        /// <summary>
-        /// This is the Position of the last chunk. All <see cref="NStore.Domain.Changeset"/> are projected
-        /// all events in a row. We do not save readmodel until all events of changeset are processed.
-        /// </summary>
+		/// <summary>
+		/// This is the Position of the last chunk. All <see cref="NStore.Domain.Changeset"/> are projected
+		/// all events in a row. We do not save readmodel until all events of changeset are processed.
+		/// </summary>
 		public Int64 ProjectedPosition { get; private set; }
 
-        /// <summary>
-        /// User that created the object, this will be the user of the first <see cref="Changeset"/>
-        /// </summary>
-        public String CreationUser { get; set; }
+		/// <summary>
+		/// User that created the object, this will be the user of the first <see cref="Changeset"/>
+		/// </summary>
+		public String CreationUser { get; set; }
 
-        /// <summary>
-        /// The user that generates last <see cref="Changeset"/>
-        /// </summary>
-        public String LastModificationUser { get; set; }
+		/// <summary>
+		/// The user that generates last <see cref="Changeset"/>
+		/// </summary>
+		public String LastModificationUser { get; set; }
 
-        /// <summary>
-        /// Last modification timestamp
-        /// </summary>
-        public DateTime LastModify { get; set; }
+		/// <summary>
+		/// Last modification timestamp
+		/// </summary>
+		public DateTime LastModify { get; set; }
 
-        /// <summary>
-        /// Version of the aggregate
-        /// </summary>
-        public Int64 AggregateVersion { get; private set; }
+		/// <summary>
+		/// Maximum number of version to keep in <see cref="LastProcessedVersions"/> we do not need to store
+		/// all versions, because honestly we do not expect to have anomalies so big that you can miss an event
+		/// and then re-dispatch after dispatched other 20 events.
+		/// </summary>
+		public const int MaxNumberOfVersionToKeep = 20;
 
-        /// <summary>
-        /// True if some processing of events thrown an exception, the readmodel
-        /// is blocked, it will not update anymore.
-        /// </summary>
-        public Boolean Faulted { get; private set; }
+		/// <summary>
+		/// To avoid creating error in projection where we have version 2 and 3 and for some reason we
+		/// dispatch version 3 before the 2, we keep a list of all version processed. This is done because
+		/// we can admit holes, so if the aggregate is in version X we can tolerate processing X+2 version
+		/// but if later X+1 is processed we have a problem and need to throw signaling that the aggregate
+		/// is faulted due to a wrong ordering.
+		/// </summary>
+		public List<long> LastProcessedVersions { get; private set; } = new List<long>();
 
-        public void MarkAsFaulted(Int64 projectedPosition)
-        {
-            ProjectedPosition = projectedPosition;
-            Faulted = true;
-        }
+		/// <summary>
+		/// Version of the aggregate
+		/// </summary>
+		public Int64 AggregateVersion { get; private set; }
 
-        private Int32? _readModelVersion;
+		/// <inheritdoc/>
+		public Boolean Faulted { get; private set; }
 
-        /// <summary>
-        /// This is a read / write property because we want this property
-        /// to be serialized in mongo and retrieved to check if the readmodel
-        /// in mongo has a different signature. Lower signature is the sign 
-        /// of an older readmodel. Higher signature is the sign of an higher 
-        /// and newer readmodel.
-        /// </summary>
-        public Int32 ReadModelVersion
-        {
-            get
-            {
-                return (_readModelVersion ?? (_readModelVersion = GetVersion())).Value;
-            }
-            set
-            {
-                _readModelVersion = value;
-            }
-        }
+		/// <inheritdoc/>
+		public int FaultRetryCount { get; private set; }
 
-        /// <summary>
-        /// <para>
-        /// If this property is true, it means that the readmodel was manipulated
-        /// in memory with events that comes from other streams (draftable) or simply
-        /// with in memory generated events.
-        /// </para>
-        /// <para>The stream should not be persisted.</para>
-        /// </summary>
-        [BsonIgnore]
-        public Boolean ModifiedWithExtraStreamEvents { get; protected set; }
+		/// <inheritdoc/>
+		public void MarkAsFaulted(Int64 projectedPosition)
+		{
+			ProjectedPosition = projectedPosition;
+			FaultRetryCount = 0;
+			Faulted = true;
+		}
 
-        protected abstract Int32 GetVersion();
+		private Int32? _readModelVersion;
 
-        protected virtual void BeforeEventProcessing(DomainEvent domainEvent)
-        {
-        }
+		/// <summary>
+		/// This is a read / write proper-ty because we want this property
+		/// to be serialized in mongo and retrieved to check if the readmodel
+		/// in mongo has a different signature. Lower signature is the sign
+		/// of an older readmodel. Higher signature is the sign of an higher
+		/// and newer readmodel.
+		/// </summary>
+		public Int32 ReadModelVersion
+		{
+			get
+			{
+				return (_readModelVersion ?? (_readModelVersion = GetVersion())).Value;
+			}
+			set
+			{
+				_readModelVersion = value;
+			}
+		}
 
-        protected virtual void AfterEventProcessing(DomainEvent domainEvent)
-        {
-        }
+		/// <summary>
+		/// <para>
+		/// If this property is true, it means that the readmodel was manipulated
+		/// in memory with events that comes from other streams (draftable) or simply
+		/// with in memory generated events.
+		/// </para>
+		/// <para>The stream should not be persisted.</para>
+		/// </summary>
+		[BsonIgnore]
+		public Boolean ModifiedWithExtraStreamEvents { get; protected set; }
 
-        private Boolean ProcessEvent(DomainEvent domainEvent)
-        {
-            //if this readmodel is faulted, it should not process anymore any data.
-            if (Faulted)
-            {
-                return false;
-            }
+		/// <inheritdoc/>
+		protected abstract Int32 GetVersion();
 
-            //remember that we have a method for each combination ReadmodelType+EventType
-            var eventType = domainEvent.GetType();
-            string key = eventType.FullName + GetType().FullName;
+		/// <inheritdoc/>
+		protected virtual void BeforeEventProcessing(DomainEvent domainEvent)
+		{
+		}
 
-            if (!_handlersCache.TryGetValue(key, out MethodInvoker invoker))
-            {
-                var methodInfo = GetType().Method("On", new Type[] { eventType }, Flags.InstancePublic | Flags.InstancePrivate);
-                if (methodInfo != null)
-                {
-                    invoker = methodInfo.DelegateForCallMethod();
-                }
-                _handlersCache.TryAdd(key, invoker);
-            }
+		/// <inheritdoc/>
+		protected virtual void AfterEventProcessing(DomainEvent domainEvent)
+		{
+		}
 
-            if (invoker != null)
-            {
-                BeforeEventProcessing(domainEvent);
-                invoker.Invoke(this, domainEvent);
-                AfterEventProcessing(domainEvent);
-                return true;
-            }
+		private Boolean ProcessEvent(DomainEvent domainEvent)
+		{
+			//if this readmodel is faulted, it should not process anymore any data.
+			if (Faulted)
+			{
+				return false;
+			}
 
-            return false;
-        }
+			//remember that we have a method for each combination ReadmodelType+EventType
+			var eventType = domainEvent.GetType();
+			string key = eventType.FullName + GetType().FullName;
 
-        /// <summary>
-        /// Process the changeset, returing true if the <see cref="Changeset"/> contains at least
-        /// one event that is handled by the readmodel.
-        /// </summary>
-        /// <param name="changeset"></param>
-        /// <returns></returns>
-        public virtual Boolean ProcessChangeset(Changeset changeset)
-        {
-            Boolean processed = false;
+			if (!_handlersCache.TryGetValue(key, out MethodInvoker invoker))
+			{
+				var methodInfo = GetType().Method("On", new Type[] { eventType }, Flags.InstancePublic | Flags.InstancePrivate);
+				if (methodInfo != null)
+				{
+					invoker = methodInfo.DelegateForCallMethod();
+				}
+				_handlersCache.TryAdd(key, invoker);
+			}
 
-            //We should process events only if the changes really HAS events and if this is not a changes of the past.
-            bool shouldProcessEvents = changeset.Events.Length > 0 && changeset.AggregateVersion > AggregateVersion;
-            if (shouldProcessEvents)
-            {
-                Int64 position = 0;
-                for (int i = 0; i < changeset.Events.Length; i++)
-                {
-                    var evt = changeset.Events[i] as DomainEvent;
-                    if (i == 0)
-                    {
-                        //First event, we need to set some standard informations. These informations
-                        //are equal for all the events of this specific changeset.
-                        LastModify = evt.CommitStamp;
-                        LastModificationUser = UserNameExtractor(evt) ?? evt.IssuedBy;
-                        AggregateVersion = changeset.AggregateVersion;
-                        if (CreationUser == null)
-                        {
-                            CreationUser = evt.IssuedBy;
-                        }
-                    }
+			if (invoker != null)
+			{
+				BeforeEventProcessing(domainEvent);
+				invoker.Invoke(this, domainEvent);
+				AfterEventProcessing(domainEvent);
+				return true;
+			}
 
-                    processed |= ProcessEvent(evt);
-                    position = evt.CheckpointToken;
-                }
-                ProjectedPosition = position;
-            }
-            return processed;
-        }
+			return false;
+		}
 
-        public void ProcessExtraStreamChangeset(Changeset changeset)
-        {
-            foreach (DomainEvent evt in changeset.Events.OfType<DomainEvent>())
-            {
-                ProcessEvent(evt);
-            }
-            ModifiedWithExtraStreamEvents = true;
-        }
+		/// <summary>
+		/// Process the changeset, returing true if the <see cref="Changeset"/> contains at least
+		/// one event that is handled by the readmodel.
+		/// </summary>
+		/// <param name="changeset"></param>
+		/// <returns></returns>
+		public virtual Boolean ProcessChangeset(Changeset changeset)
+		{
+			Boolean processed = false;
 
-        private static readonly ConcurrentDictionary<string, MethodInvoker> _handlersCache = new ConcurrentDictionary<string, MethodInvoker>();
-    }
+			//We should process events only if the changes really HAS events and if this is not a changes of the past.
+			if (changeset.AggregateVersion < this.AggregateVersion && !LastProcessedVersions.Contains(changeset.AggregateVersion))
+			{
+				//ok we have old changeset that was not dispatched, but this will generate exception if it is not so old
+				//we keep track of MaxNumberOfVersionToKeep in a special array to keep track of holes in last MaxNumberOfVersionToKeep
+				//Versions, for older version we cannot throw we can only skip.
+				if (changeset.AggregateVersion > this.AggregateVersion - MaxNumberOfVersionToKeep)
+				{
+					throw new JarvisFrameworkEngineException($"WRONG PROCESS ORDER FOR ATOMIC READMODEL: Readmodel {Id} we are dispatching checkpoint {changeset.GetChunkPosition()} that has version {changeset.AggregateVersion} less than actual ReadmodelVersion that is at version {this.AggregateVersion} and version {changeset.AggregateVersion} was never dispatched in the past.");
+				}
+			}
+
+			//now understand if this event must be processed for idempotency.
+			bool shouldProcessEvents = changeset.Events.Length > 0 && changeset.AggregateVersion > AggregateVersion;
+			if (shouldProcessEvents)
+			{
+				Int64 position = 0;
+				for (int i = 0; i < changeset.Events.Length; i++)
+				{
+					var evt = changeset.Events[i] as DomainEvent;
+					if (i == 0)
+					{
+						//First event, we need to set some standard informations. These informations
+						//are equal for all the events of this specific changeset. 
+
+						var id = evt.AggregateId;
+						if (this.Id != id)
+						{
+							throw new JarvisFrameworkEngineException($"We are trying to project an event of aggregate {evt.AggregateId} on a readmodel with id {this.Id}");
+						}
+						LastModify = evt.CommitStamp;
+						LastModificationUser = UserNameExtractor(evt) ?? evt.IssuedBy;
+						AggregateVersion = changeset.AggregateVersion;
+						if (CreationUser == null)
+						{
+							CreationUser = evt.IssuedBy;
+						}
+					}
+
+					processed |= ProcessEvent(evt);
+					position = evt.CheckpointToken;
+				}
+				ProjectedPosition = position;
+			}
+			AddLastProcessedVersion(changeset.AggregateVersion);
+			return processed;
+		}
+
+		private void AddLastProcessedVersion(long aggregateVersion)
+		{
+			if (LastProcessedVersions == null) LastProcessedVersions = new List<long>();
+			if (LastProcessedVersions.Count > MaxNumberOfVersionToKeep - 1)
+			{
+				LastProcessedVersions.RemoveAt(0);
+			}
+			LastProcessedVersions.Add(aggregateVersion);
+		}
+
+		/// <inheritdoc/>
+		public void ProcessExtraStreamChangeset(Changeset changeset)
+		{
+			foreach (DomainEvent evt in changeset.Events.OfType<DomainEvent>())
+			{
+				ProcessEvent(evt);
+			}
+			ModifiedWithExtraStreamEvents = true;
+		}
+
+		private static readonly ConcurrentDictionary<string, MethodInvoker> _handlersCache = new ConcurrentDictionary<string, MethodInvoker>();
+	}
 }

--- a/Jarvis.Framework.Shared/ReadModel/Atomic/IAtomicReadModel.cs
+++ b/Jarvis.Framework.Shared/ReadModel/Atomic/IAtomicReadModel.cs
@@ -3,72 +3,78 @@ using System;
 
 namespace Jarvis.Framework.Shared.ReadModel.Atomic
 {
-    public interface IAtomicReadModel : IReadModel
-    {
-        /// <summary>
-        /// This is the id of the atomic readmodel.
-        /// </summary>
-        String Id { get; }
+	public interface IAtomicReadModel : IReadModel
+	{
+		/// <summary>
+		/// This is the id of the atomic readmodel.
+		/// </summary>
+		String Id { get; }
 
-        /// <summary>
-        /// <para>
-        /// This is the position of last projection changeset.
-        /// </para>
-        /// <para>It is used to guarantee idempotency on write</para>
-        /// </summary>
-        Int64 ProjectedPosition { get; }
+		/// <summary>
+		/// <para>
+		/// This is the position of last projection changeset.
+		/// </para>
+		/// <para>It is used to guarantee idempotency on write</para>
+		/// </summary>
+		Int64 ProjectedPosition { get; }
 
-        /// <summary>
-        /// Position of the specific stream that was projected.
-        /// </summary>
-        Int64 AggregateVersion { get; }
+		/// <summary>
+		/// Position of the specific stream that was projected.
+		/// </summary>
+		Int64 AggregateVersion { get; }
 
-        /// <summary>
-        /// Signature identify when a readmodel change, it should be changed every time
-        /// that the readmodel changes.
-        /// </summary>
-        Int32 ReadModelVersion { get; }
+		/// <summary>
+		/// Signature identify when a readmodel change, it should be changed every time
+		/// that the readmodel changes.
+		/// </summary>
+		Int32 ReadModelVersion { get; }
 
-        /// <summary>
-        /// This property is set to true if processing some events raised error in the 
-        /// readmodel.
-        /// </summary>
-        Boolean Faulted { get; }
+		/// <summary>
+		/// This property is set to true if processing some events raised error in the
+		/// readmodel.
+		/// </summary>
+		Boolean Faulted { get; }
 
-        /// <summary>
-        /// This is a specific property that tells to the persistence wrapper that this
-        /// specific readmodel cannot be persisted anymore because something happened like
-        /// processing <see cref="Changeset"/> that comes from a different stream or from
-        /// a Draft Stream.
-        /// </summary>
-        Boolean ModifiedWithExtraStreamEvents { get; }
+		/// <summary>
+		/// Number of time that we tried to reproject the entire stream of events to
+		/// fix the readmodel, it is needed to limit the number of time we can try to fix
+		/// the readmodel.
+		/// </summary>
+		int FaultRetryCount { get; }
 
-        /// <summary>
-        /// Mark the readmodel as faulted.
-        /// </summary>
-        /// <returns></returns>
-        void MarkAsFaulted(Int64 projectedPosition);
+		/// <summary>
+		/// This is a specific property that tells to the persistence wrapper that this
+		/// specific readmodel cannot be persisted anymore because something happened like
+		/// processing <see cref="Changeset"/> that comes from a different stream or from
+		/// a Draft Stream.
+		/// </summary>
+		Boolean ModifiedWithExtraStreamEvents { get; }
 
-        /// <summary>
-        /// A readmodel atomic is capable of processing events.
-        /// </summary>
-        /// <param name="changeset"></param>
-        Boolean ProcessChangeset(Changeset changeset);
+		/// <summary>
+		/// Mark the readmodel as faulted.
+		/// </summary>
+		/// <param name="projectedPosition">Position that caused failure</param>
+		void MarkAsFaulted(Int64 projectedPosition);
 
-        /// <summary>
-        /// <para>
-        /// To allow support for Draftable, we need to have a different
-        /// method that will process the changeset that comes from a different
-        /// persistence storage.
-        /// </para>
-        /// <para>
-        /// This a concept where the readmodel will process a changeset that is not
-        /// part of the stream, this should prevent the readmodel from being saved again
-        /// to disk because it could generate confusion.
-        /// </para>
-        /// </summary>
-        /// <param name="changeset"></param>
-        /// <returns></returns>
-        void ProcessExtraStreamChangeset(Changeset changeset);
-    }
+		/// <summary>
+		/// A readmodel atomic is capable of processing events.
+		/// </summary>
+		/// <param name="changeset"></param>
+		Boolean ProcessChangeset(Changeset changeset);
+
+		/// <summary>
+		/// <para>
+		/// To allow support for Draftable, we need to have a different
+		/// method that will process the changeset that comes from a different
+		/// persistence storage.
+		/// </para>
+		/// <para>
+		/// This a concept where the readmodel will process a changeset that is not
+		/// part of the stream, this should prevent the readmodel from being saved again
+		/// to disk because it could generate confusion.
+		/// </para>
+		/// </summary>
+		/// <param name="changeset"></param>
+		void ProcessExtraStreamChangeset(Changeset changeset);
+	}
 }

--- a/Jarvis.Framework.Shared/ReadModel/Atomic/ILiveAtomicMultistreamReadModelProcessor.cs
+++ b/Jarvis.Framework.Shared/ReadModel/Atomic/ILiveAtomicMultistreamReadModelProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Jarvis.Framework.Shared.ReadModel.Atomic
 {
@@ -12,5 +13,87 @@ namespace Jarvis.Framework.Shared.ReadModel.Atomic
 	/// </summary>
 	public interface ILiveAtomicMultistreamReadModelProcessor
 	{
+		/// <summary>
+		/// Project multiple aggregate id, each one with potentially multiple <see cref="IAtomicReadModel"/>
+		/// in a single call. Used to project a complete scenario in the past.
+		/// </summary>
+		/// <param name="request">List of aggregate to project.</param>
+		/// <param name="checkpointUpToIncluded">Global checkpoint, included, to use as a limit for projection</param>
+		/// <returns></returns>
+		Task<MultiStreamProcessorResult> ProcessAsync(IReadOnlyCollection<MultiStreamProcessRequest> request, Int64 checkpointUpToIncluded);
+
+		/// <summary>
+		/// Project multiple aggregate id, each one with potentially multiple <see cref="IAtomicReadModel"/> in a single
+		/// call up to a certain timestamp in the past.
+		/// </summary>
+		/// <param name="request">List of aggregate to project.</param>
+		/// <param name="dateTimeUpTo">Project up to that date.</param>
+		/// <returns></returns>
+		Task<MultiStreamProcessorResult> ProcessAsync(IReadOnlyCollection<MultiStreamProcessRequest> request, DateTime dateTimeUpTo);
+	}
+
+	/// <summary>
+	/// If we need to project more than one aggregate we need to specify a different 
+	/// information for each aggregate. This structure contains information needed to 
+	/// project a single aggregate.
+	/// </summary>
+	public struct MultiStreamProcessRequest
+	{
+		/// <summary>
+		/// Default constructor.
+		/// </summary>
+		/// <param name="aggregateId"></param>
+		/// <param name="readmodelTypes"></param>
+		public MultiStreamProcessRequest(string aggregateId, IEnumerable<Type> readmodelTypes)
+		{
+			AggregateId = aggregateId;
+			ReadmodelTypes = readmodelTypes;
+		}
+
+		/// <summary>
+		/// Id of the aggregate we want to project
+		/// </summary>
+		public string AggregateId { get; private set; }
+
+		/// <summary>
+		/// Corresponding readmodel we want to project for aggregate with id <see cref="AggregateId"/>
+		/// </summary>
+		public IEnumerable<Type> ReadmodelTypes { get; private set; }
+	}
+
+	/// <summary>
+	/// Contains result of a multi stream multi readmodel projection, this will project
+	/// more than one PartionId in NStore where each stream can have more than one
+	/// readmodel.
+	/// </summary>
+	public class MultiStreamProcessorResult
+	{
+		private Dictionary<string, IReadOnlyCollection<IAtomicReadModel>> _readmodels;
+
+		internal MultiStreamProcessorResult(ICollection<IReadOnlyCollection<IAtomicReadModel>> readModels)
+		{
+			_readmodels = readModels
+				.Where(r => r.Count > 0)
+				.ToDictionary(r => r.First().Id);
+		}
+
+		/// <summary>
+		/// Grab a readmodel, if no event is present no readmodel is created and the return
+		/// value is null.
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="id"></param>
+		/// <returns></returns>
+		/// <exception cref="NotImplementedException"></exception>
+		public T Get<T>(string id) where T : IAtomicReadModel
+		{
+			if (!_readmodels.TryGetValue(id, out var readmodels))
+			{
+				return default;
+			}
+
+			var rm = (T)readmodels.FirstOrDefault(r => r.GetType() == typeof(T));
+			return rm?.AggregateVersion > 0 ? rm : default;
+		}
 	}
 }

--- a/Jarvis.Framework.Shared/ReadModel/Atomic/ILiveAtomicMultistreamReadModelProcessor.cs
+++ b/Jarvis.Framework.Shared/ReadModel/Atomic/ILiveAtomicMultistreamReadModelProcessor.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jarvis.Framework.Shared.ReadModel.Atomic
+{
+	/// <summary>
+	/// Introduced with #44 this interface is an extension to <see cref="ILiveAtomicReadModelProcessor"/>
+	/// that will allow to project more than one stream into one or more atomic readmodel. This is usually used
+	/// to solve the situation where we need to project a series of stream up to a point in time with multiple
+	/// readmodels.
+	/// </summary>
+	public interface ILiveAtomicMultistreamReadModelProcessor
+	{
+	}
+}

--- a/Jarvis.Framework.TestHelpers/Jarvis.Framework.TestHelpers.csproj
+++ b/Jarvis.Framework.TestHelpers/Jarvis.Framework.TestHelpers.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="MongoDB.Driver.Core" Version="2.18.0" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NStore.Core" Version="0.13.1" />
-    <PackageReference Include="NStore.Domain" Version="0.13.1" />
-    <PackageReference Include="NStore.Persistence.Mongo" Version="0.13.1" />
+    <PackageReference Include="NStore.Core" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Domain" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Persistence.Mongo" Version="0.14.0-alpha.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 

--- a/Jarvis.Framework.Tests/EngineTests/ComplexAggregate.cs
+++ b/Jarvis.Framework.Tests/EngineTests/ComplexAggregate.cs
@@ -1,0 +1,84 @@
+﻿using Jarvis.Framework.Kernel.Engine;
+using Jarvis.Framework.Shared.Events;
+using Jarvis.Framework.Shared.IdentitySupport;
+using Jarvis.Framework.Shared.ReadModel.Atomic;
+using Jarvis.Framework.Shared.Store;
+using System.Collections.Generic;
+
+namespace Jarvis.Framework.Tests.EngineTests
+{
+	public class ComplexAggregateId : EventStoreIdentity
+	{
+		public ComplexAggregateId(long id) : base(id)
+		{
+		}
+
+		public ComplexAggregateId(string id) : base(id)
+		{
+		}
+	}
+
+	public class ComplexAggregate : AggregateRoot<ComplexAggregate.ComplexAggregateState, ComplexAggregateId>
+	{
+		public class ComplexAggregateState : JarvisAggregateState
+		{
+		}
+
+		public void Create()
+		{
+			RaiseEvent(new ComplexAggregateBorn());
+		}
+
+		public void Done(string value)
+		{
+			RaiseEvent(new ComplexAggregateDone(value));
+		}
+	}
+
+	[VersionInfo(Version = 1, Name = "ComplexAggregateBorn")]
+	public class ComplexAggregateBorn : DomainEvent
+	{
+	}
+
+	[VersionInfo(Version = 1, Name = "ComplexAggregateDone")]
+	public class ComplexAggregateDone : DomainEvent
+	{
+		public ComplexAggregateDone(string value)
+		{
+			Value = value;
+		}
+
+		public string Value { get; set; }
+	}
+
+	public class ComplexAggregateReadModel : AbstractAtomicReadModel
+	{
+		public ComplexAggregateReadModel(string id) : base(id)
+		{
+		}
+
+		protected override int GetVersion()
+		{
+			return 1;
+		}
+
+		public bool Born { get; set; }
+
+		public List<string> DoneValues { get; set; } = new List<string>();
+
+#pragma warning disable RCS1213 // Remove unused member declaration.
+#pragma warning disable IDE0051 // Remove unused private members
+		private void On(ComplexAggregateBorn _)
+		{
+			Born = true;
+		}
+
+		private void On(ComplexAggregateDone evt)
+		{
+			DoneValues.Add(evt.Value);
+		}
+
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore RCS1213 // Remove unused member declaration.
+	}
+}

--- a/Jarvis.Framework.Tests/Jarvis.Framework.Tests.csproj
+++ b/Jarvis.Framework.Tests/Jarvis.Framework.Tests.csproj
@@ -23,9 +23,9 @@
     <PackageReference Include="MongoDB.Driver.Core" Version="2.18.0" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NStore.Core" Version="0.13.1" />
-    <PackageReference Include="NStore.Domain" Version="0.13.1" />
-    <PackageReference Include="NStore.Persistence.Mongo" Version="0.13.1" />
+    <PackageReference Include="NStore.Core" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Domain" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Persistence.Mongo" Version="0.14.0-alpha.10" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/Jarvis.Framework.Tests/ProjectionEngineTests/V2/PollerCanStopAndRestart.cs
+++ b/Jarvis.Framework.Tests/ProjectionEngineTests/V2/PollerCanStopAndRestart.cs
@@ -1,87 +1,83 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Threading;
-using Jarvis.Framework.Kernel.Events;
+﻿using Jarvis.Framework.Kernel.Events;
 using Jarvis.Framework.Kernel.ProjectionEngine;
 using Jarvis.Framework.Shared.IdentitySupport;
 using Jarvis.Framework.Shared.Messages;
-using Jarvis.Framework.Shared.ReadModel;
-using Jarvis.Framework.TestHelpers;
 using Jarvis.Framework.Tests.EngineTests;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Jarvis.Framework.Tests.ProjectionEngineTests.V2
 {
-    //[TestFixture("1")]
-    [TestFixture("2")]
-    public class PollerCanStopAndRestart : AbstractV2ProjectionEngineTests
-    {
-        public PollerCanStopAndRestart(String pollingClientVersion) : base(pollingClientVersion)
-        {
+	//[TestFixture("1")]
+	[TestFixture("2")]
+	public class PollerCanStopAndRestart : AbstractV2ProjectionEngineTests
+	{
+		public PollerCanStopAndRestart(String pollingClientVersion) : base(pollingClientVersion)
+		{
+		}
 
-        }
+		protected override void RegisterIdentities(IdentityManager identityConverter)
+		{
+			identityConverter.RegisterIdentitiesFromAssembly(typeof(SampleAggregateId).Assembly);
+		}
 
-        protected override void RegisterIdentities(IdentityManager identityConverter)
-        {
-            identityConverter.RegisterIdentitiesFromAssembly(typeof(SampleAggregateId).Assembly);
-        }
+		protected override string GetConnectionString()
+		{
+			return ConfigurationManager.ConnectionStrings["engine"].ConnectionString;
+		}
 
-        protected override string GetConnectionString()
-        {
-            return ConfigurationManager.ConnectionStrings["engine"].ConnectionString;
-        }
+		protected override IEnumerable<IProjection> BuildProjections()
+		{
+			var writer = new CollectionWrapper<SampleReadModel, string>(StorageFactory, new NotifyToNobody());
+			yield return new Projection(writer);
+		}
 
-        protected override IEnumerable<IProjection> BuildProjections()
-        {
-            var writer = new CollectionWrapper<SampleReadModel, string>(StorageFactory,new NotifyToNobody());
-            yield return new Projection(writer);
-        }
+		protected override Task OnStartPolling()
+		{
+			return Engine.StartAsync();
+		}
 
-        protected override Task OnStartPolling()
-        {
-            return Engine.StartAsync();
-        }
+		[Test]
+		public async Task stop_and_restart_polling_should_work()
+		{
+			var aggregate = await Repository.GetByIdAsync<SampleAggregate>(new SampleAggregateId(1)).ConfigureAwait(false);
+			aggregate.Create();
+			await Repository.SaveAsync(aggregate, Guid.NewGuid().ToString(), h => { }).ConfigureAwait(false);
 
-        [Test]
-        public async Task stop_and_restart_polling_should_work()
-        {
-            var aggregate = await Repository.GetByIdAsync < SampleAggregate>(new SampleAggregateId(1)).ConfigureAwait(false);
-            aggregate.Create();
-            await Repository.SaveAsync(aggregate,Guid.NewGuid().ToString(), h => { }).ConfigureAwait(false);
+			Boolean checkpointPassed = WaitForCheckpoint(1);
+			Assert.IsTrue(checkpointPassed, "Automatic poller does not work.");
 
-            Boolean checkpointPassed = WaitForCheckpoint(1);
-            Assert.IsTrue(checkpointPassed, "Automatic poller does not work.");
+			Engine.Stop();
 
-            Engine.Stop();
+			aggregate = await Repository.GetByIdAsync<SampleAggregate>(new SampleAggregateId(2)).ConfigureAwait(false);
+			aggregate.Create();
+			await Repository.SaveAsync(aggregate, Guid.NewGuid().ToString(), h => { }).ConfigureAwait(false);
 
-            aggregate = await Repository.GetByIdAsync < SampleAggregate>(new SampleAggregateId(2)).ConfigureAwait(false);
-            aggregate.Create();
-            await Repository.SaveAsync(aggregate,Guid.NewGuid().ToString(), h => { }).ConfigureAwait(false);
+			checkpointPassed = WaitForCheckpoint(2);
+			Assert.IsFalse(checkpointPassed, "Automatic poller is still working after stop.");
 
-            checkpointPassed = WaitForCheckpoint(2);
-            Assert.IsFalse(checkpointPassed, "Automatic poller is still working after stop.");
+			await Engine.StartAsync().ConfigureAwait(false);
 
-            await Engine.StartAsync().ConfigureAwait(false);
+			checkpointPassed = WaitForCheckpoint(2);
+			Assert.IsTrue(checkpointPassed, "Automatic poller is not restarted correctly.");
+		}
 
-            checkpointPassed = WaitForCheckpoint(2);
-            Assert.IsTrue(checkpointPassed, "Automatic poller is not restarted correctly.");
-        }
+		private Boolean WaitForCheckpoint(Int64 checkpointToken)
+		{
+			DateTime startTime = DateTime.Now;
+			Boolean passed = false;
+			while (
+				!(passed = _statusChecker.IsCheckpointProjectedByAllProjection(checkpointToken))
+				&& DateTime.Now.Subtract(startTime).TotalMilliseconds < 7000)
 
-        private Boolean WaitForCheckpoint(Int64 checkpointToken)
-        {
-            DateTime startTime = DateTime.Now;
-            Boolean passed = false;
-            while (
-                !(passed = _statusChecker.IsCheckpointProjectedByAllProjection(checkpointToken))
-                && DateTime.Now.Subtract(startTime).TotalMilliseconds < 7000)
-
-            {
-                Thread.Sleep(100);
-            }
-            return passed;
-        }
-    }
+			{
+				Thread.Sleep(100);
+			}
+			return passed;
+		}
+	}
 }

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/AtomicProjectionEngineTestBase.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/AtomicProjectionEngineTestBase.cs
@@ -68,6 +68,7 @@ namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic
 
             GenerateContainer();
             SimpleTestAtomicReadModel.TouchMax = Int32.MaxValue;
+            SimpleTestAtomicReadModel.GenerateInternalExceptionforMaxTouch = false;
         }
 
         private static IPersistence CreatePersistence()

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/AtomicProjectionEngineTestBase.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/AtomicProjectionEngineTestBase.cs
@@ -122,7 +122,7 @@ namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic
                     .For<AtomicProjectionEngine>()
                     .ImplementedBy<AtomicProjectionEngine>(),
                 Component
-                    .For<ILiveAtomicReadModelProcessor, ILiveAtomicReadModelProcessorEnhanced>()
+                    .For<ILiveAtomicReadModelProcessor, ILiveAtomicMultistreamReadModelProcessor, ILiveAtomicReadModelProcessorEnhanced>()
                     .ImplementedBy<LiveAtomicReadModelProcessor>(),
                 Component
                     .For<ICommitPollingClient>()
@@ -184,10 +184,10 @@ namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic
 
         protected Int64 lastUsedPosition;
 
-        protected Task<Changeset> GenerateCreatedEvent(String issuedBy = null)
+        protected Task<Changeset> GenerateCreatedEvent(String issuedBy = null, DateTime? timestamp = null)
         {
             var evt = new SampleAggregateCreated();
-            SetBasePropertiesToEvent(evt, issuedBy);
+            SetBasePropertiesToEvent(evt, issuedBy, timestamp: timestamp);
             return ProcessEvent(evt);
         }
 
@@ -307,12 +307,12 @@ namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic
         {
         }
 
-        protected async Task<Changeset> GenerateSomeChangesetsAndReturnLatestsChangeset()
+        protected async Task<Changeset> GenerateSomeChangesetsAndReturnLatestsChangeset(DateTime? timestamp = null)
         {
             //Three events all generated in datbase
-            await GenerateCreatedEvent().ConfigureAwait(false);
-            await GenerateTouchedEvent().ConfigureAwait(false);
-            return await GenerateTouchedEvent().ConfigureAwait(false);
+            await GenerateCreatedEvent(timestamp: timestamp).ConfigureAwait(false);
+            await GenerateTouchedEvent(timestamp: timestamp).ConfigureAwait(false);
+            return await GenerateTouchedEvent(timestamp: timestamp).ConfigureAwait(false);
         }
 
         protected static void SetBasePropertiesToEvent(DomainEvent evt, string issuedBy, DateTime? timestamp = null)

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/AtomicReadmodelTests.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/AtomicReadmodelTests.cs
@@ -1,189 +1,309 @@
 ﻿using Jarvis.Framework.Shared.Events;
+using Jarvis.Framework.Shared.Exceptions;
 using Jarvis.Framework.Shared.Helpers;
+using Jarvis.Framework.Shared.ReadModel.Atomic;
 using Jarvis.Framework.Tests.EngineTests;
 using Jarvis.Framework.Tests.ProjectionsTests.Atomic.Support;
 using NUnit.Framework;
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic
 {
-    [TestFixture]
-    public class AtomicReadmodelTests : AtomicProjectionEngineTestBase
-    {
-        [Test]
-        public async Task Verify_basic_dispatch_of_changeset()
-        {
-            var cs = await GenerateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
+	[TestFixture]
+	public class AtomicReadmodelTests : AtomicProjectionEngineTestBase
+	{
+		[Test]
+		public async Task Verify_basic_dispatch_of_changeset()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
 
-            Assert.That(rm.ProjectedPosition, Is.EqualTo(cs.GetChunkPosition()));
-        }
+			Assert.That(rm.ProjectedPosition, Is.EqualTo(cs.GetChunkPosition()));
+		}
 
-        [Test]
-        public async Task Verify_correctly_return_of_handled_event()
-        {
-            var cs = await GenerateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
+		[Test]
+		public async Task Verify_track_of_version_processed()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
 
-            Assert.IsTrue(rm.Created);
-        }
+			Assert.That(rm.LastProcessedVersions, Is.EquivalentTo(new[] { 1 }));
+		}
 
-        [Test]
-        public async Task Verify_cache_does_not_dispatch_wrong_event()
-        {
-            //ok process a created event
-            var cs = await GenerateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
+		[Test]
+		public async Task Verify_track_of_version_processed_maintain_last_events()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
 
-            //then take a different readmodel that does not consume that element
-            ++_aggregateIdSeed;
-            var rm2 = new SimpleAtomicAggregateReadModel(new AtomicAggregateId(_aggregateIdSeed));
-            var processed = rm2.ProcessChangeset(cs);
+			for (int i = 0; i < AbstractAtomicReadModel.MaxNumberOfVersionToKeep + 10; i++)
+			{
+				cs = await GenerateTouchedEvent();
+				rm.ProcessChangeset(cs);
+			}
 
-            Assert.IsFalse(processed);
-        }
+			Assert.That(rm.LastProcessedVersions.Count, Is.EqualTo(AbstractAtomicReadModel.MaxNumberOfVersionToKeep));
 
-        [Test]
-        public async Task Verify_cache_does_not_dispatch_wrong_event_to_reamodel_of_same_aggregate()
-        {
-            //ok process a created event
-            var cs = await GenerateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
+			List<long> expectedSequence = new List<long>();
+			long actualVersion = cs.AggregateVersion;
+			while (expectedSequence.Count < AbstractAtomicReadModel.MaxNumberOfVersionToKeep)
+			{
+				expectedSequence.Add(actualVersion--);
+			}
 
-            //then take a different readmodel that does not consume that element
-            ++_aggregateIdSeed;
-            var rm2 = new AnotherSimpleTestAtomicReadModel(new AtomicAggregateId(_aggregateIdSeed));
-            var processed = rm2.ProcessChangeset(cs);
+			//Verify exact sequence, ordered from less to most recent
+			expectedSequence.Reverse();
+			Assert.That(rm.LastProcessedVersions, Is.EqualTo(expectedSequence));
+		}
 
-            Assert.IsTrue(processed);
-            Assert.That(rm2.Created, Is.True);
-        }
+		[Test]
+		public async Task Verify_correctly_return_of_handled_event()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
 
-        [Test]
-        public async Task Verify_correctly_return_of_handled_event_even_if_a_single_Event_is_handled()
-        {
-            var cs = await GenerateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
+			Assert.IsTrue(rm.Created);
+		}
 
-            var evta = new SampleAggregateDerived1();
-            var evtb = new SampleAggregateTouched();
-            var cs2 = await ProcessEvents(new DomainEvent[] { evta, evtb }, p => new AtomicAggregateId(p)).ConfigureAwait(false);
-            Assert.IsTrue(rm.ProcessChangeset(cs2));
-        }
+		//[Test]
+		//public async Task Verify_cache_does_not_dispatch_wrong_event()
+		//{
+		//	//ok process a created event
+		//	var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+		//	var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+		//	rm.ProcessChangeset(cs);
 
-        [Test]
-        public async Task Verify_correctly_return_false_of_Unhandled_event()
-        {
-            var cs = await GenerateSampleAggregateDerived1().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            Assert.IsFalse(rm.ProcessChangeset(cs));
-        }
+		//	//then take a different readmodel that does not consume that element
+		//	++_aggregateIdSeed;
+		//	var rm2 = new SimpleAtomicAggregateReadModel(new AtomicAggregateId(_aggregateIdSeed));
+		//	var processed = rm2.ProcessChangeset(cs);
 
-        [Test]
-        public async Task Verify_basic_dispatch_of_two_changeset()
-        {
-            var cs = await GenerateAtomicAggregateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
-            var touch = await GenerateTouchedEvent().ConfigureAwait(false);
-            rm.ProcessChangeset(touch);
+		//	Assert.IsFalse(processed);
+		//}
 
-            Assert.That(rm.ProjectedPosition, Is.EqualTo(touch.GetChunkPosition()));
-        }
+		[Test]
+		public async Task Verify_cache_does_not_dispatch_wrong_event_to_reamodel_of_same_aggregate()
+		{
+			//ok process a created event
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
 
-        [Test]
-        public async Task Verify_idempotence_of_changeest_processing()
-        {
-            var cs = await GenerateAtomicAggregateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
-            var touch = await GenerateTouchedEvent().ConfigureAwait(false);
-            rm.ProcessChangeset(touch);
+			//Generate another id, then let second readmodel process a changeset that is not 
+			//meant to be consumed by that aggregate.
+			++_aggregateIdSeed;
+			var rm2 = new AnotherSimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			Assert.Throws<JarvisFrameworkEngineException>(() => rm2.ProcessChangeset(cs));
+		}
 
-            Assert.That(rm.TouchCount, Is.EqualTo(1));
+		[Test]
+		public async Task Verify_correctly_return_of_handled_event_even_if_a_single_Event_is_handled()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
 
-            rm.ProcessChangeset(touch);
+			var evta = new SampleAggregateDerived1();
+			var evtb = new SampleAggregateTouched();
+			var cs2 = await ProcessEvents(new DomainEvent[] { evta, evtb }, p => new SampleAggregateId(p)).ConfigureAwait(false);
+			Assert.IsTrue(rm.ProcessChangeset(cs2));
+		}
 
-            Assert.That(rm.TouchCount, Is.EqualTo(1));
-        }
+		[Test]
+		public async Task Verify_correctly_return_false_of_Unhandled_event()
+		{
+			var cs = await GenerateSampleAggregateDerived1().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			Assert.IsFalse(rm.ProcessChangeset(cs));
+		}
 
-        [Test]
-        public async Task Verify_idempotence_of_changeest_processing_past_event()
-        {
-            var cs = await GenerateAtomicAggregateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
-            var touch = await GenerateTouchedEvent().ConfigureAwait(false);
-            rm.ProcessChangeset(touch);
+		[Test]
+		public async Task Verify_basic_dispatch_of_two_changeset()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(cs.GetIdentity().AsString());
+			rm.ProcessChangeset(cs);
+			var touch = await GenerateTouchedEvent().ConfigureAwait(false);
+			rm.ProcessChangeset(touch);
 
-            Assert.That(rm.TouchCount, Is.EqualTo(1));
+			Assert.That(rm.ProjectedPosition, Is.EqualTo(touch.GetChunkPosition()));
+		}
 
-            var touch2 = await GenerateTouchedEvent().ConfigureAwait(false);
-            rm.ProcessChangeset(touch2);
-            //reprocess past event.
-            rm.ProcessChangeset(touch);
+		[Test]
+		public async Task Verify_idempotence_of_changeest_processing()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
+			var touch = await GenerateTouchedEvent().ConfigureAwait(false);
+			rm.ProcessChangeset(touch);
 
-            Assert.That(rm.TouchCount, Is.EqualTo(2));
-        }
+			Assert.That(rm.TouchCount, Is.EqualTo(1));
 
-        [Test]
-        public async Task Verify_processing_event_with_holes()
-        {
-            var cs = await GenerateAtomicAggregateCreatedEvent().ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
-            var touch1 = await GenerateTouchedEvent().ConfigureAwait(false);
-            var touch2 = await GenerateTouchedEvent().ConfigureAwait(false);
+			var processed = rm.ProcessChangeset(touch);
 
-            rm.ProcessChangeset(touch2);
-            Assert.That(rm.TouchCount, Is.EqualTo(1), "We can process event even if there are holes.");
+			Assert.That(processed, Is.False);
+			Assert.That(rm.TouchCount, Is.EqualTo(1));
+		}
 
-            rm.ProcessChangeset(touch1);
-            Assert.That(rm.TouchCount, Is.EqualTo(1), "Past events should not be processed");
-        }
+		[Test]
+		public async Task Verify_idempotence_of_changeset_processing_past_event()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
+			var touch = await GenerateTouchedEvent().ConfigureAwait(false);
+			rm.ProcessChangeset(touch);
 
-        [Test]
-        public async Task Verify_basic_properties()
-        {
-            var cs = await GenerateCreatedEvent(issuedBy : "admin").ConfigureAwait(false);
-            var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
-            rm.ProcessChangeset(cs);
+			Assert.That(rm.TouchCount, Is.EqualTo(1));
 
-            Assert.That(rm.CreationUser, Is.EqualTo("admin"));
-            Assert.That(rm.LastModificationUser, Is.EqualTo("admin"));
-            Assert.That(rm.LastModify, Is.EqualTo(((DomainEvent)cs.Events[0]).CommitStamp));
-            Assert.That(rm.AggregateVersion, Is.EqualTo(cs.AggregateVersion));
+			var touch2 = await GenerateTouchedEvent().ConfigureAwait(false);
+			rm.ProcessChangeset(touch2);
 
-            cs = await GenerateTouchedEvent(issuedBy: "admin2").ConfigureAwait(false);
-            rm.ProcessChangeset(cs);
+			//reprocess past event.
+			rm.ProcessChangeset(touch);
 
-            Assert.That(rm.CreationUser, Is.EqualTo("admin"));
-            Assert.That(rm.LastModificationUser, Is.EqualTo("admin2"));
-            Assert.That(rm.LastModify, Is.EqualTo(((DomainEvent)cs.Events[0]).CommitStamp));
-            Assert.That(rm.AggregateVersion, Is.EqualTo(cs.AggregateVersion));
-        }
+			Assert.That(rm.TouchCount, Is.EqualTo(2));
+		}
 
-        [Test]
-        public async Task When_event_is_not_handled_reamodel_should_not_marked_as_changed()
-        {
-            var cs = await GenerateCreatedEvent(issuedBy: "admin").ConfigureAwait(false);
-            var rm = new SimpleAtomicReadmodelWithSingleEventHandled(new SampleAggregateId(_aggregateIdSeed));
+		/// <summary>
+		/// <para>
+		/// This is somewhat controversial test, if we were to redispatch a past event
+		/// we must ignore it only if it was correctly handled, or we can create problem.
+		/// </para>
+		/// <para>
+		/// We have three events dispatched in order 1, 3, 2 => no error will be raised, 
+		/// event 2 will be ignored.
+		/// </para>
+		/// </summary>
+		/// <returns></returns>
+		[Test]
+		public async Task Verify_processing_event_with_holes()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
+			var event_empty_generated_to_increment_counter = await GenerateTouchedEvent().ConfigureAwait(false);
+			var touch2 = await GenerateTouchedEvent().ConfigureAwait(false);
 
-            Assert.That(rm.AggregateVersion, Is.EqualTo(0), "Uninitialized Atomic reamodel should have 0 as version");
+			//Suppose touch1 event is simply missing so it will not be dispatched because it is empty
+			//we need to be able to continue processing events.
+			rm.ProcessChangeset(touch2);
+			Assert.That(rm.TouchCount, Is.EqualTo(1), "We can process event even if there are holes.");
+			Assert.That(rm.AggregateVersion, Is.EqualTo(3), "Aggregate has an hole, no problem");
+		}
 
-            var processed = rm.ProcessChangeset(cs);
-            Assert.That(processed, Is.False, "That readmodel does not process Created event so it should communicate that the event is not handled");
+		[Test]
+		public async Task Verify_dispatching_in_wrong_order()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
+			var touch1 = await GenerateTouchedEvent().ConfigureAwait(false);
+			var touch2 = await GenerateTouchedEvent().ConfigureAwait(false);
 
-            cs = await GenerateTouchedEvent(issuedBy: "admin2").ConfigureAwait(false);
-            processed = rm.ProcessChangeset(cs);
+			//we dispatch touch2 events, like in the event of an hole
+			rm.ProcessChangeset(touch2);
+			Assert.That(rm.TouchCount, Is.EqualTo(1), "We can process event even if there are holes.");
 
-            Assert.IsTrue(processed, "Touched event should be processed");
-        }
-    }
+			//Then we try to re-dispatch older event, we need to raise exception
+			Assert.Throws<JarvisFrameworkEngineException>(() => rm.ProcessChangeset(touch1), "Dispatch old events that was not present in the list");
+		}
+
+		/// <summary>
+		/// We keep a certain number of version processed in LastProcessedVersions property, but
+		/// when this information become stale, we tolerate re-dispatch.
+		/// </summary>
+		/// <returns></returns>
+		[Test]
+		public async Task Verify_dispatching_in_wrong_order_tolerate_skew()
+		{
+			var cs = await GenerateCreatedEvent().ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
+			var touch1 = await GenerateTouchedEvent().ConfigureAwait(false);
+
+			//Now process more event that we can keep in memory in the readmodel.
+			for (int i = 0; i < AbstractAtomicReadModel.MaxNumberOfVersionToKeep + 1; i++)
+			{
+				var evt = await GenerateTouchedEvent().ConfigureAwait(false);
+				rm.ProcessChangeset(evt);
+			}
+
+			//Then we try to re-dispatch older event, we need to raise exception
+			Assert.DoesNotThrow(() => rm.ProcessChangeset(touch1), "Tolerate undispatched event because is really old");
+		}
+
+		[Test]
+		public async Task Verify_basic_properties()
+		{
+			var cs = await GenerateCreatedEvent(issuedBy: "admin").ConfigureAwait(false);
+			var rm = new SimpleTestAtomicReadModel(new SampleAggregateId(_aggregateIdSeed));
+			rm.ProcessChangeset(cs);
+
+			Assert.That(rm.CreationUser, Is.EqualTo("admin"));
+			Assert.That(rm.LastModificationUser, Is.EqualTo("admin"));
+			Assert.That(rm.LastModify, Is.EqualTo(((DomainEvent)cs.Events[0]).CommitStamp));
+			Assert.That(rm.AggregateVersion, Is.EqualTo(cs.AggregateVersion));
+
+			cs = await GenerateTouchedEvent(issuedBy: "admin2").ConfigureAwait(false);
+			rm.ProcessChangeset(cs);
+
+			Assert.That(rm.CreationUser, Is.EqualTo("admin"));
+			Assert.That(rm.LastModificationUser, Is.EqualTo("admin2"));
+			Assert.That(rm.LastModify, Is.EqualTo(((DomainEvent)cs.Events[0]).CommitStamp));
+			Assert.That(rm.AggregateVersion, Is.EqualTo(cs.AggregateVersion));
+		}
+
+		[Test]
+		public async Task When_event_is_not_handled_reamodel_should_not_marked_as_changed()
+		{
+			var cs = await GenerateCreatedEvent(issuedBy: "admin").ConfigureAwait(false);
+			var rm = new SimpleAtomicReadmodelWithSingleEventHandled(new SampleAggregateId(_aggregateIdSeed));
+
+			Assert.That(rm.AggregateVersion, Is.EqualTo(0), "Uninitialized Atomic reamodel should have 0 as version");
+
+			var processed = rm.ProcessChangeset(cs);
+			Assert.That(processed, Is.False, "That readmodel does not process Created event so it should communicate that the event is not handled");
+
+			cs = await GenerateTouchedEvent(issuedBy: "admin2").ConfigureAwait(false);
+			processed = rm.ProcessChangeset(cs);
+
+			Assert.IsTrue(processed, "Touched event should be processed");
+		}
+
+		[Test]
+		public async Task Tolerate_dispatching_wrong_aggregate_events()
+		{
+			var cs = await GenerateCreatedEvent(issuedBy: "admin").ConfigureAwait(false);
+			var rm = new SimpleSubAtomicAggregateReadModel(new SubAtomicAggregateId(_aggregateIdSeed));
+
+			//we are processing a changeset that is of another stream, but the readmodel has no way to 
+			//understand that this is a commit that does not belongs to him. 
+			Assert.Throws<JarvisFrameworkEngineException>(() => rm.ProcessChangeset(cs));
+		}
+
+		[Test]
+		public async Task Tolerate_dispatching_different_id_event()
+		{
+			var cs1 = await GenerateCreatedEvent(issuedBy: "admin").ConfigureAwait(false);
+			_aggregateIdSeed++;
+			var cs2 = await GenerateCreatedEvent(issuedBy: "admin").ConfigureAwait(false);
+
+			var rm = new SimpleSubAtomicAggregateReadModel(cs1.GetIdentity().AsString());
+
+			Assert.DoesNotThrow(() => rm.ProcessChangeset(cs1));
+
+			Assert.That(rm.AggregateVersion, Is.EqualTo(1L));
+
+			//we are processing a changeset that is of another stream, but the readmodel has no way to 
+			//understand that this is a commit that does not belongs to him. 
+			Assert.Throws<JarvisFrameworkEngineException>(() => rm.ProcessChangeset(cs2));
+		}
+	}
 }

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/LiveAtomicMultistreamReadModelProcessorTests.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/LiveAtomicMultistreamReadModelProcessorTests.cs
@@ -1,0 +1,188 @@
+﻿using Jarvis.Framework.Shared.Helpers;
+using Jarvis.Framework.Shared.IdentitySupport;
+using Jarvis.Framework.Shared.ReadModel.Atomic;
+using Jarvis.Framework.Tests.EngineTests;
+using Jarvis.Framework.Tests.ProjectionsTests.Atomic.Support;
+using NStore.Domain;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic
+{
+	[TestFixture]
+	public class LiveAtomicMultistreamReadModelProcessorTests : AtomicProjectionEngineTestBase
+	{
+		private Changeset c1, c2, c3, c4, c5, c6, c7;
+		private DateTime sequence1, sequence2, sequence3;
+
+		[Test]
+		public async Task Project_up_until_certain_checkpoint_all_projection()
+		{
+			await CreateScenario().ConfigureAwait(false);
+
+			//ok now we can start to test
+			var sut = _container.Resolve<ILiveAtomicMultistreamReadModelProcessor>();
+
+			//ok now we want to project multiple stuff
+			List<MultiStreamProcessRequest> request = new List<MultiStreamProcessRequest>
+			{
+				new MultiStreamProcessRequest(c1.GetIdentity().AsString(), new Type[] { typeof(SimpleTestAtomicReadModel) }),
+				new MultiStreamProcessRequest(c4.GetIdentity().AsString(), new Type[] { typeof(ComplexAggregateReadModel) })
+			};
+
+			//project everything up to the most up to date stuff
+			var result = await sut.ProcessAsync(request, c7.GetChunkPosition());
+			var rms = result.Get<SimpleTestAtomicReadModel>(c1.GetIdentity().AsString());
+			Assert.That(rms.TouchCount, Is.EqualTo(4));
+			Assert.That(rms.AggregateVersion, Is.EqualTo(c7.AggregateVersion));
+
+			var cms = result.Get<ComplexAggregateReadModel>(c4.GetIdentity().AsString());
+			Assert.That(cms.Born, Is.True);
+			Assert.That(cms.DoneValues, Is.EquivalentTo(new[] { "done1", "done2" }));
+			Assert.That(cms.AggregateVersion, Is.EqualTo(c6.AggregateVersion));
+		}
+
+		[Test]
+		public async Task Get_wrong_readmodel_return_null()
+		{
+			await CreateScenario().ConfigureAwait(false);
+
+			//ok now we can start to test
+			var sut = _container.Resolve<ILiveAtomicMultistreamReadModelProcessor>();
+
+			//ok now we want to project multiple stuff
+			List<MultiStreamProcessRequest> request = new List<MultiStreamProcessRequest>
+			{
+				new MultiStreamProcessRequest(c1.GetIdentity().AsString(), new Type[] { typeof(SimpleTestAtomicReadModel) }),
+				new MultiStreamProcessRequest(c4.GetIdentity().AsString(), new Type[] { typeof(ComplexAggregateReadModel) })
+			};
+
+			//project everything up to the most up to date stuff
+			var result = await sut.ProcessAsync(request, c7.GetChunkPosition());
+
+			var rms = result.Get<SimpleTestAtomicReadModel>(c4.GetIdentity().AsString());
+			Assert.That(rms, Is.Null);
+		}
+
+		[Test]
+		public async Task Argument_check_for_nullability_chunk_position()
+		{
+			await CreateScenario().ConfigureAwait(false);
+
+			//ok now we can start to test
+			var sut = _container.Resolve<ILiveAtomicMultistreamReadModelProcessor>();
+			Assert.ThrowsAsync<ArgumentNullException>(async () => await sut.ProcessAsync(null, c7.GetChunkPosition()));
+
+			//empty does not throw
+			Assert.DoesNotThrowAsync(async () => await sut.ProcessAsync(new List<MultiStreamProcessRequest>(), c7.GetChunkPosition()));
+		}
+
+		[Test]
+		public async Task Argument_check_for_nullability_datetime()
+		{
+			await CreateScenario().ConfigureAwait(false);
+
+			//ok now we can start to test
+			var sut = _container.Resolve<ILiveAtomicMultistreamReadModelProcessor>();
+			Assert.ThrowsAsync<ArgumentNullException>(async () => await sut.ProcessAsync(null, DateTime.UtcNow));
+
+			//empty does not throw
+			Assert.DoesNotThrowAsync(async () => await sut.ProcessAsync(new List<MultiStreamProcessRequest>(), DateTime.UtcNow));
+		}
+
+		[Test]
+		public async Task Project_up_until_certain_checkpoint_number()
+		{
+			await CreateScenario().ConfigureAwait(false);
+
+			//ok now we can start to test
+			var sut = _container.Resolve<ILiveAtomicMultistreamReadModelProcessor>();
+
+			//ok now we want to project multiple stuff
+			List<MultiStreamProcessRequest> request = new List<MultiStreamProcessRequest>
+			{
+				new MultiStreamProcessRequest(c1.GetIdentity().AsString(), new Type[] { typeof(SimpleTestAtomicReadModel) }),
+				new MultiStreamProcessRequest(c4.GetIdentity().AsString(), new Type[] { typeof(ComplexAggregateReadModel) })
+			};
+
+			//in c3 first aggregate exists, second aggregate no
+			var result = await sut.ProcessAsync(request, c3.GetChunkPosition());
+			var rms = result.Get<SimpleTestAtomicReadModel>(c1.GetIdentity().AsString());
+			Assert.That(rms.TouchCount, Is.EqualTo(3));
+			Assert.That(rms.AggregateVersion, Is.EqualTo(c2.AggregateVersion));
+
+			var cms = result.Get<ComplexAggregateReadModel>(c4.GetIdentity().AsString());
+			Assert.IsNull(cms);
+
+			var other = result.Get<ComplexAggregateReadModel>(c3.GetIdentity().AsString());
+			Assert.IsNull(other);
+		}
+
+		[Test]
+		public async Task Project_up_until_certain_time_all_projection()
+		{
+			await CreateScenario().ConfigureAwait(false);
+
+			//ok now we can start to test
+			var sut = _container.Resolve<ILiveAtomicMultistreamReadModelProcessor>();
+
+			//ok now we want to project multiple stuff
+			List<MultiStreamProcessRequest> request = new List<MultiStreamProcessRequest>
+			{
+				new MultiStreamProcessRequest(c1.GetIdentity().AsString(), new Type[] { typeof(SimpleTestAtomicReadModel) }),
+				new MultiStreamProcessRequest(c4.GetIdentity().AsString(), new Type[] { typeof(ComplexAggregateReadModel) })
+			};
+
+			//project everything up to the most up to date stuff
+			var result = await sut.ProcessAsync(request, sequence2);
+
+			var rms = result.Get<SimpleTestAtomicReadModel>(c1.GetIdentity().AsString());
+			Assert.That(rms.TouchCount, Is.EqualTo(3));
+			Assert.That(rms.AggregateVersion, Is.EqualTo(c2.AggregateVersion));
+
+			var cms = result.Get<ComplexAggregateReadModel>(c4.GetIdentity().AsString());
+			Assert.That(cms.Born, Is.True);
+			Assert.That(cms.DoneValues, Is.EquivalentTo(new[] { "done1" }));
+			Assert.That(cms.AggregateVersion, Is.EqualTo(c5.AggregateVersion));
+		}
+
+		private async Task CreateScenario()
+		{
+			sequence1 = new DateTime(2010, 10, 10);
+			sequence2 = sequence1.AddDays(1);
+			sequence3 = sequence1.AddDays(3);
+
+			c1 = await GenerateSomeChangesetsAndReturnLatestsChangeset(sequence1).ConfigureAwait(false);
+			c2 = await GenerateTouchedEvent(timestamp: sequence2).ConfigureAwait(false);
+			_aggregateIdSeed++;
+			c3 = await GenerateSomeChangesetsAndReturnLatestsChangeset(sequence2).ConfigureAwait(false);
+			_aggregateIdSeed++;
+			//a complete different aggregate
+			c4 = await GenerateBornEvent(sequence2);
+			c5 = await GenerateComplexDoneEvent("done1", timeStamp: sequence2);
+			c6 = await GenerateComplexDoneEvent("done2", timeStamp: sequence3);
+
+			//now again the first aggregate
+			var savedAggregateId = _aggregateIdSeed;
+			_aggregateIdSeed = ((EventStoreIdentity)c1.GetIdentity()).Id;
+			c7 = await GenerateTouchedEvent().ConfigureAwait(false);
+			_aggregateIdSeed = savedAggregateId;
+		}
+
+		protected Task<Changeset> GenerateBornEvent(DateTime? timeStamp = null)
+		{
+			var evt = new ComplexAggregateBorn();
+			SetBasePropertiesToEvent(evt, null, timestamp: timeStamp);
+			return ProcessEvent(evt, id => new ComplexAggregateId(id));
+		}
+
+		protected Task<Changeset> GenerateComplexDoneEvent(String value, DateTime? timeStamp = null)
+		{
+			var evt = new ComplexAggregateDone(value);
+			SetBasePropertiesToEvent(evt, null, timestamp: timeStamp);
+			return ProcessEvent(evt, id => new ComplexAggregateId(id));
+		}
+	}
+}

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/ResiliencyAtomicProjectionTEsts.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/ResiliencyAtomicProjectionTEsts.cs
@@ -1,58 +1,132 @@
-﻿using Jarvis.Framework.Shared.Events;
+﻿using Fasterflect;
+using Jarvis.Framework.Kernel.ProjectionEngine.Atomic;
+using Jarvis.Framework.Shared.Events;
 using Jarvis.Framework.Shared.Helpers;
+using Jarvis.Framework.Shared.ReadModel.Atomic;
 using Jarvis.Framework.Tests.ProjectionsTests.Atomic.Support;
 using NStore.Domain;
 using NUnit.Framework;
+using System;
 using System.Threading.Tasks;
 
 namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic
 {
-    [TestFixture]
-    public class ResiliencyAtomicProjectionTests : AtomicProjectionEngineTestBase
-    {
-        [Test]
-        public async Task Verify_exceptions_are_handled_for_specific_instance_of_readmodel()
-        {
-            SimpleTestAtomicReadModel.TouchMax = 1; //we want at maximum one touch.
+	[TestFixture]
+	public class ResiliencyAtomicProjectionTests : AtomicProjectionEngineTestBase
+	{
+		[Test]
+		public async Task Verify_exceptions_are_handled_for_specific_instance_of_readmodel()
+		{
+			SimpleTestAtomicReadModel.TouchMax = 1; //we want at maximum one touch.
 
-            //first step, create two touch events, the second one generates a problem
-            Changeset changeset = await GenerateSomeChangesetsAndReturnLatestsChangeset().ConfigureAwait(false);
+			//first step, create two touch events, the second one generates a problem
+			Changeset changeset = await GenerateSomeChangesetsAndReturnLatestsChangeset().ConfigureAwait(false);
 
-            _aggregateIdSeed++; //start working on another aggregate
-            var secondAggregateChangeset = await GenerateCreatedEvent().ConfigureAwait(false);
+			_aggregateIdSeed++; //start working on another aggregate
+			var secondAggregateChangeset = await GenerateCreatedEvent().ConfigureAwait(false);
 
-            //And finally check if everything is projected
-            var sut = await CreateSutAndStartProjectionEngineAsync().ConfigureAwait(false);
+			//And finally check if everything is projected
+			var sut = await CreateSutAndStartProjectionEngineAsync().ConfigureAwait(false);
 
-            //we need to wait to understand if it was projected
-            GetTrackerAndWaitForChangesetToBeProjected( "SimpleTestAtomicReadModel");
+			//we need to wait to understand if it was projected
+			GetTrackerAndWaitForChangesetToBeProjected("SimpleTestAtomicReadModel");
 
-            //First readmodel have only one touch
-            var evt = changeset.Events[0] as DomainEvent;
-            var rm = await _collection.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
-            Assert.That(rm.TouchCount, Is.EqualTo(1));
-            Assert.That(rm.Faulted);
+			//First readmodel have only one touch
+			var evt = changeset.Events[0] as DomainEvent;
+			var rm = await _collection.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
+			Assert.That(rm.TouchCount, Is.EqualTo(1));
+			Assert.That(rm.Faulted);
+			Assert.That(rm.AggregateVersion, Is.EqualTo(3)); //Exception is thrown during third event so we have version 3 processed with error
 
-            //but the second aggregate should be projected.
-            evt = secondAggregateChangeset.Events[0] as DomainEvent;
-            rm = await _collection.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
-            Assert.That(rm.ProjectedPosition, Is.EqualTo(evt.CheckpointToken));
-            Assert.That(rm.Created, Is.EqualTo(true));
-            Assert.That(rm.TouchCount, Is.EqualTo(0));
+			//but the second aggregate should be projected.
+			evt = secondAggregateChangeset.Events[0] as DomainEvent;
+			rm = await _collection.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
+			Assert.That(rm.ProjectedPosition, Is.EqualTo(evt.CheckpointToken));
+			Assert.That(rm.Created, Is.EqualTo(true));
+			Assert.That(rm.TouchCount, Is.EqualTo(0));
 
-            //another event
-            var anotherchangeset = await GenerateTouchedEvent().ConfigureAwait(false);
+			//another event
+			var anotherchangeset = await GenerateTouchedEvent().ConfigureAwait(false);
 
-            //we need to wait to understand if it was projected
-            GetTrackerAndWaitForChangesetToBeProjected( "SimpleTestAtomicReadModel");
+			//we need to wait to understand if it was projected
+			GetTrackerAndWaitForChangesetToBeProjected("SimpleTestAtomicReadModel");
 
-            await sut.StopAsync().ConfigureAwait(false);
+			await sut.StopAsync().ConfigureAwait(false);
 
-            rm = await _collection.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
-            evt = anotherchangeset.Events[0] as DomainEvent;
-            Assert.That(rm.ProjectedPosition, Is.EqualTo(evt.CheckpointToken));
-            Assert.That(rm.Created, Is.EqualTo(true));
-            Assert.That(rm.TouchCount, Is.EqualTo(1));
-        }
-    }
+			rm = await _collection.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
+			evt = anotherchangeset.Events[0] as DomainEvent;
+			Assert.That(rm.ProjectedPosition, Is.EqualTo(evt.CheckpointToken));
+			Assert.That(rm.Created, Is.EqualTo(true));
+			Assert.That(rm.TouchCount, Is.EqualTo(1));
+		}
+
+		[Test]
+		public async Task Verify_framework_internal_exception_can_be_automatically_fixed()
+		{
+			//Simulate generation of an internal exception, 
+			SimpleTestAtomicReadModel.TouchMax = 1; //we want at maximum one touch to generate exception
+			SimpleTestAtomicReadModel.GenerateInternalExceptionforMaxTouch = true;
+
+			//first step, create two touch events, the second one generates a problem
+			Changeset changeset = await GenerateSomeChangesetsAndReturnLatestsChangeset().ConfigureAwait(false);
+
+			//And finally check if everything is projected
+			await CreateSutAndStartProjectionEngineAsync().ConfigureAwait(false);
+
+			//we need to wait to understand if it was projected
+			GetTrackerAndWaitForChangesetToBeProjected("SimpleTestAtomicReadModel");
+
+			//First readmodel have only one touch
+			SimpleTestAtomicReadModel.TouchMax = Int32.MaxValue;
+			var evt = changeset.Events[0] as DomainEvent;
+			var wrapper = _container.Resolve<IAtomicCollectionWrapper<SimpleTestAtomicReadModel>>();
+			var rm = await wrapper.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
+
+			Assert.That(rm.Faulted, Is.False);
+			Assert.That(rm.TouchCount, Is.EqualTo(2));
+			Assert.That(rm.AggregateVersion, Is.EqualTo(3));
+		}
+
+		[Test]
+		public async Task Verify_framework_internal_exception_fixer_does_not_impede_reading()
+		{
+			//Simulate generation of an internal exception, 
+			SimpleTestAtomicReadModel.TouchMax = 1; //we want at maximum one touch to generate exception
+			SimpleTestAtomicReadModel.GenerateInternalExceptionforMaxTouch = true;
+
+			//first step, create two touch events, the second one generates a problem
+			Changeset changeset = await GenerateSomeChangesetsAndReturnLatestsChangeset().ConfigureAwait(false);
+
+			//And finally check if everything is projected
+			await CreateSutAndStartProjectionEngineAsync().ConfigureAwait(false);
+
+			//we need to wait to understand if it was projected
+			GetTrackerAndWaitForChangesetToBeProjected("SimpleTestAtomicReadModel");
+
+			//First readmodel have only one touch
+			var evt = changeset.Events[0] as DomainEvent;
+			var wrapper = _container.Resolve<IAtomicCollectionWrapper<SimpleTestAtomicReadModel>>();
+			var rm = await wrapper.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
+
+			Assert.That(rm.Faulted);
+			Assert.That(rm.FaultRetryCount, Is.EqualTo(0)); //Fault retry was saved in database but it is not immedaitely visible
+			Assert.That(rm.TouchCount, Is.EqualTo(1)); //second touch gnerated another exception.
+			Assert.That(rm.AggregateVersion, Is.EqualTo(3)); //Created, then 
+
+			rm = await wrapper.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
+
+			Assert.That(rm.Faulted);
+			Assert.That(rm.FaultRetryCount, Is.EqualTo(1), "Increment failure count"); //we have 1 failure retry, previous one.
+			Assert.That(rm.TouchCount, Is.EqualTo(1)); //second touch gnerated another exception.
+			Assert.That(rm.AggregateVersion, Is.EqualTo(3)); //Created, then 
+
+			for (int i = 0; i < AtomicMongoCollectionWrapper<SimpleTestAtomicReadModel>.MaxNumberOfRetryToReprojectFaultedReadmodels; i++)
+			{
+				rm = await wrapper.FindOneByIdAsync(evt.AggregateId).ConfigureAwait(false);
+			}
+
+			Assert.That(rm.Faulted);
+			Assert.That(rm.FaultRetryCount, Is.EqualTo(AtomicMongoCollectionWrapper<SimpleTestAtomicReadModel>.MaxNumberOfRetryToReprojectFaultedReadmodels), "Too much retry");
+		}
+	}
 }

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/Support/SimpleTestAtomicReadModel.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/Support/SimpleTestAtomicReadModel.cs
@@ -1,5 +1,6 @@
 ﻿using Jarvis.Framework.Kernel.ProjectionEngine.Atomic;
 using Jarvis.Framework.Shared.Events;
+using Jarvis.Framework.Shared.Exceptions;
 using Jarvis.Framework.Shared.ReadModel.Atomic;
 using Jarvis.Framework.Tests.EngineTests;
 using System;
@@ -7,75 +8,85 @@ using System.Threading.Tasks;
 
 namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic.Support
 {
-    [AtomicReadmodelInfo("SimpleTestAtomicReadModel", typeof(SampleAggregateId))]
-    public class SimpleTestAtomicReadModel : AbstractAtomicReadModel
-    {
-        public SimpleTestAtomicReadModel(string id) : base(id)
-        {
-        }
+	[AtomicReadmodelInfo("SimpleTestAtomicReadModel", typeof(SampleAggregateId))]
+	public class SimpleTestAtomicReadModel : AbstractAtomicReadModel
+	{
+		public SimpleTestAtomicReadModel(string id) : base(id)
+		{
+		}
 
-        public Int32 TouchCount { get; private set; }
+		public Int32 TouchCount { get; private set; }
 
-        public Boolean Created { get; private set; }
+		public Boolean Created { get; private set; }
 
-        public String ExtraString { get; set; }
+		public String ExtraString { get; set; }
 
-        protected override void BeforeEventProcessing(DomainEvent domainEvent)
-        {
-            ExtraString += $"B-{domainEvent.MessageId}";
-            base.BeforeEventProcessing(domainEvent);
-        }
+		protected override void BeforeEventProcessing(DomainEvent domainEvent)
+		{
+			ExtraString += $"B-{domainEvent.MessageId}";
+			base.BeforeEventProcessing(domainEvent);
+		}
 
-        protected override void AfterEventProcessing(DomainEvent domainEvent)
-        {
-            ExtraString += $"A-{domainEvent.MessageId}";
-            base.AfterEventProcessing(domainEvent);
-        }
+		protected override void AfterEventProcessing(DomainEvent domainEvent)
+		{
+			ExtraString += $"A-{domainEvent.MessageId}";
+			base.AfterEventProcessing(domainEvent);
+		}
 
-#pragma warning disable S1144 // Unused private types or members should be removed
-#pragma warning disable S1172 // Unused method parameters should be removed
-        private void On(SampleAggregateCreated evt)
-        {
-            ExtraString += $"IN-{evt.MessageId}";
-            Created = true;
-            TouchCount = 0;
-        }
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable RCS1213 // Remove unused member declaration.
+		private void On(SampleAggregateCreated evt)
+		{
+			ExtraString += $"IN-{evt.MessageId}";
+			Created = true;
+			TouchCount = 0;
+		}
 
-        private void On(SampleAggregateTouched evt)
-        {
-            if (TouchCount >= TouchMax)
-                throw new Exception();
+		private void On(SampleAggregateTouched _)
+		{
+			if (TouchCount >= TouchMax)
+			{
+				if (GenerateInternalExceptionforMaxTouch)
+				{
+					throw new JarvisFrameworkEngineException("Internal exception for test");
+				}
+				else
+				{
+					throw new Exception("Exception for test");
+				}
+			}
 
-            TouchCount += FakeSignature;
-        }
-#pragma warning restore S1172 // Unused method parameters should be removed
-#pragma warning restore S1144 // Unused private types or members should be removed
+			TouchCount += FakeSignature;
+		}
+#pragma warning restore RCS1213 // Remove unused member declaration.
+#pragma warning restore IDE0051 // Remove unused private members
 
-        protected override int GetVersion()
-        {
-            return FakeSignature;
-        }
+		protected override int GetVersion()
+		{
+			return FakeSignature;
+		}
 
-        public static Int32 FakeSignature { get; set; }
+		public static Int32 FakeSignature { get; set; }
 
-        public static Int32 TouchMax { get; set; } = Int32.MaxValue;
-    }
+		public static Int32 TouchMax { get; set; } = Int32.MaxValue;
+		public static bool GenerateInternalExceptionforMaxTouch { get; set; }
+	}
 
-    public class SimpleTestAtomicReadModelInitializer : IAtomicReadModelInitializer
-    {
-        private readonly IAtomicCollectionWrapper<SimpleTestAtomicReadModel> _atomicCollectionWrapper;
+	public class SimpleTestAtomicReadModelInitializer : IAtomicReadModelInitializer
+	{
+		private readonly IAtomicCollectionWrapper<SimpleTestAtomicReadModel> _atomicCollectionWrapper;
 
-        public SimpleTestAtomicReadModelInitializer(IAtomicCollectionWrapper<SimpleTestAtomicReadModel> atomicCollectionWrapper)
-        {
-            _atomicCollectionWrapper = atomicCollectionWrapper;
-        }
+		public SimpleTestAtomicReadModelInitializer(IAtomicCollectionWrapper<SimpleTestAtomicReadModel> atomicCollectionWrapper)
+		{
+			_atomicCollectionWrapper = atomicCollectionWrapper;
+		}
 
-        public Boolean Initialized { get; set; }
+		public Boolean Initialized { get; set; }
 
-        public Task Initialize()
-        {
-            Initialized = true;
-            return Task.CompletedTask;
-        }
-    }
+		public Task Initialize()
+		{
+			Initialized = true;
+			return Task.CompletedTask;
+		}
+	}
 }

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/Support/SubatomicAggregate.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/Support/SubatomicAggregate.cs
@@ -1,0 +1,81 @@
+﻿using Jarvis.Framework.Kernel.Engine;
+using Jarvis.Framework.Shared.Events;
+using Jarvis.Framework.Shared.IdentitySupport;
+using Jarvis.Framework.Shared.ReadModel.Atomic;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic.Support
+{
+    /// <summary>
+    /// Another aggregate used to test atomic readmodels.
+    /// </summary>
+    public class SubAtomicAggregateId : EventStoreIdentity
+    {
+        public SubAtomicAggregateId(long id) : base(id)
+        {
+        }
+
+        public SubAtomicAggregateId(string id) : base(id)
+        {
+        }
+    }
+
+    public class SubAtomicAggregate : AggregateRoot<SubAtomicAggregate.SubSampleAggregateState, SubAtomicAggregateId>
+    {
+        public class SubSampleAggregateState : JarvisAggregateState
+        {
+        }
+
+        public void Create()
+        {
+            RaiseEvent(new AtomicAggregateCreated());
+        }
+    }
+
+    public class SubAtomicAggregateCreated : DomainEvent
+    {
+    }
+
+	public class SubAtomicAggregatePoked : DomainEvent
+	{
+        public SubAtomicAggregatePoked(string pokeReason)
+        {
+			PokeReason = pokeReason;
+		}
+
+		public string PokeReason { get; private set; }
+	}
+
+	[AtomicReadmodelInfo("SimpleAtomicAggregateReadModel", typeof(AtomicAggregateId))]
+    public class SimpleSubAtomicAggregateReadModel : AbstractAtomicReadModel
+    {
+        public SimpleSubAtomicAggregateReadModel(string id) : base(id)
+        {
+        }
+
+        public bool Created { get; private set; }
+
+        public List<string> PokeReasons { get; private set; } = new List<string>();
+
+        protected override int GetVersion()
+        {
+            return 1;
+        }
+
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable RCS1213 // Remove unused member declaration.
+		private void On(SubAtomicAggregateCreated _)
+
+		{
+            Created = true;
+        }
+
+		private void On(SubAtomicAggregatePoked evt)
+		{
+            PokeReasons.Add(evt.PokeReason);
+		}
+#pragma warning restore RCS1213 // Remove unused member declaration.
+#pragma warning restore IDE0051 // Remove unused private members
+	}
+}

--- a/Jarvis.Framework/Jarvis.Framework.csproj
+++ b/Jarvis.Framework/Jarvis.Framework.csproj
@@ -30,9 +30,9 @@
     <PackageReference Include="MongoDB.Driver.Core" Version="2.18.0" />
     <PackageReference Include="MongoDB.Libmongocrypt" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="NStore.Core" Version="0.13.1" />
-    <PackageReference Include="NStore.Domain" Version="0.13.1" />
-    <PackageReference Include="NStore.Persistence.Mongo" Version="0.13.1" />
+    <PackageReference Include="NStore.Core" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Domain" Version="0.14.0-alpha.10" />
+    <PackageReference Include="NStore.Persistence.Mongo" Version="0.14.0-alpha.10" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
   </ItemGroup>
 

--- a/Jarvis.Framework/ProjectionEngine/Atomic/AtomicReadmodelMultiAggregateSubscription.cs
+++ b/Jarvis.Framework/ProjectionEngine/Atomic/AtomicReadmodelMultiAggregateSubscription.cs
@@ -1,0 +1,84 @@
+﻿using Jarvis.Framework.Kernel.ProjectionEngine.Client;
+using Jarvis.Framework.Shared.Helpers;
+using NStore.Core.Persistence;
+using NStore.Domain;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Jarvis.Framework.Shared.ReadModel.Atomic
+{
+	/// <summary>
+	/// Subscription for NStore to project multiple identity, multiple
+	/// readmodels.
+	/// </summary>
+	public sealed class AtomicReadmodelMultiAggregateSubscription : ISubscription
+	{
+		private readonly ICommitEnhancer _commitEnhancer;
+		private readonly IDictionary<string, IReadOnlyCollection<IAtomicReadModel>> _projectionInstructions;
+		private readonly Func<Changeset, Boolean> _stopCondition;
+
+		/// <summary>
+		/// Project an atomic readmodel.
+		/// </summary>
+		/// <param name="commitEnhancer"></param>
+		/// <param name="projectionInstructions">A dictionary where we have aggregate id as a key, and the
+		/// list of associated readmodel as value.</param>
+		/// <param name="stopCondition">This condition will be evaluated BEFORE the changeset will be processed
+		/// by the readmodel, if the return value is true, the iteration will stop.</param>
+		public AtomicReadmodelMultiAggregateSubscription(
+			ICommitEnhancer commitEnhancer,
+			IDictionary<string, IReadOnlyCollection<IAtomicReadModel>> projectionInstructions,
+			Func<Changeset, Boolean> stopCondition)
+		{
+			_commitEnhancer = commitEnhancer;
+			_projectionInstructions = projectionInstructions;
+			_stopCondition = stopCondition;
+		}
+
+		/// <inheritdoc/>
+		public Task CompletedAsync(long indexOrPosition)
+		{
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc/>
+		public Task OnErrorAsync(long indexOrPosition, Exception ex)
+		{
+			throw ex;
+		}
+
+		/// <inheritdoc/>
+		public Task<bool> OnNextAsync(IChunk chunk)
+		{
+			_commitEnhancer.Enhance(chunk);
+			if (chunk.Payload is Changeset cs)
+			{
+				if (_stopCondition(cs))
+				{
+					return Task.FromResult(false);
+				}
+				if (_projectionInstructions.TryGetValue(cs.GetIdentity().AsString(), out var readmodelList))
+				{
+					foreach (var rm in readmodelList)
+					{
+						rm.ProcessChangeset(cs);
+					}
+				}
+			}
+			return Task.FromResult(true);
+		}
+
+		/// <inheritdoc/>
+		public Task OnStartAsync(long indexOrPosition)
+		{
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc/>
+		public Task StoppedAsync(long indexOrPosition)
+		{
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Jarvis.Framework/ProjectionEngine/Atomic/LiveAtomicReadModelProcessor.cs
+++ b/Jarvis.Framework/ProjectionEngine/Atomic/LiveAtomicReadModelProcessor.cs
@@ -11,72 +11,108 @@ using static MongoDB.Driver.WriteConcern;
 namespace Jarvis.Framework.Kernel.ProjectionEngine.Atomic
 {
 	/// <inheritdoc/>
-	public class LiveAtomicReadModelProcessor : ILiveAtomicReadModelProcessor, ILiveAtomicReadModelProcessorEnhanced
+	public class LiveAtomicReadModelProcessor : ILiveAtomicReadModelProcessor, ILiveAtomicMultistreamReadModelProcessor, ILiveAtomicReadModelProcessorEnhanced
 	{
-        private readonly ICommitEnhancer _commitEnhancer;
-        private readonly IPersistence _persistence;
-        private readonly IAtomicReadModelFactory _atomicReadModelFactory;
+		private readonly ICommitEnhancer _commitEnhancer;
+		private readonly IPersistence _persistence;
+		private readonly IAtomicReadModelFactory _atomicReadModelFactory;
 
-        /// <summary>
-        /// Default constructor
-        /// </summary>
-        /// <param name="atomicReadModelFactory"></param>
-        /// <param name="commitEnhancer"></param>
-        /// <param name="persistence"></param>
-        public LiveAtomicReadModelProcessor(
-            IAtomicReadModelFactory atomicReadModelFactory,
-            ICommitEnhancer commitEnhancer,
-            IPersistence persistence)
-        {
-            _commitEnhancer = commitEnhancer;
-            _persistence = persistence;
-            _atomicReadModelFactory = atomicReadModelFactory;
-        }
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="atomicReadModelFactory"></param>
+		/// <param name="commitEnhancer"></param>
+		/// <param name="persistence"></param>
+		public LiveAtomicReadModelProcessor(
+			IAtomicReadModelFactory atomicReadModelFactory,
+			ICommitEnhancer commitEnhancer,
+			IPersistence persistence)
+		{
+			_commitEnhancer = commitEnhancer;
+			_persistence = persistence;
+			_atomicReadModelFactory = atomicReadModelFactory;
+		}
 
-        /// <inheritdoc/>
-        public async Task<TModel> ProcessAsync<TModel>(String id, Int64 versionUpTo)
-            where TModel : IAtomicReadModel
-        {
-            //Stop condition is version greater than the version we want to apply
-            var readmodel = _atomicReadModelFactory.Create<TModel>(id);
-            var subscription = new AtomicReadModelSubscription<TModel>(_commitEnhancer, readmodel, cs => cs.AggregateVersion > versionUpTo);
-            await _persistence.ReadForwardAsync(id, 0, subscription).ConfigureAwait(false);
-            return readmodel.AggregateVersion == 0 ? default : readmodel;
-        }
+		/// <inheritdoc/>
+		public async Task<TModel> ProcessAsync<TModel>(String id, Int64 versionUpTo)
+			where TModel : IAtomicReadModel
+		{
+			//Stop condition is version greater than the version we want to apply
+			var readmodel = _atomicReadModelFactory.Create<TModel>(id);
+			var subscription = new AtomicReadModelSubscription<TModel>(_commitEnhancer, readmodel, cs => cs.AggregateVersion > versionUpTo);
+			await _persistence.ReadForwardAsync(id, 0, subscription).ConfigureAwait(false);
+			return readmodel.AggregateVersion == 0 ? default : readmodel;
+		}
 
 		/// <inheritdoc/>
 		public async Task<TModel> ProcessAsyncUntilChunkPosition<TModel>(string id, long positionUpTo) where TModel : IAtomicReadModel
-        {
-            var readmodel = _atomicReadModelFactory.Create<TModel>(id);
-            var subscription = new AtomicReadModelSubscription<TModel>(_commitEnhancer, readmodel, cs => cs.GetChunkPosition() > positionUpTo);
-            await _persistence.ReadForwardAsync(id, 0, subscription, Int64.MaxValue).ConfigureAwait(false);
-            return readmodel.AggregateVersion == 0 ? default : readmodel;
-        }
+		{
+			var readmodel = _atomicReadModelFactory.Create<TModel>(id);
+			var subscription = new AtomicReadModelSubscription<TModel>(_commitEnhancer, readmodel, cs => cs.GetChunkPosition() > positionUpTo);
+			await _persistence.ReadForwardAsync(id, 0, subscription, Int64.MaxValue).ConfigureAwait(false);
+			return readmodel.AggregateVersion == 0 ? default : readmodel;
+		}
 
 		/// <inheritdoc/>
 		public Task CatchupAsync<TModel>(TModel readModel) where TModel : IAtomicReadModel
-        {
-            var subscription = new AtomicReadModelSubscription<TModel>(_commitEnhancer, readModel, cs => false);
-            return _persistence.ReadForwardAsync(readModel.Id, readModel.AggregateVersion + 1, subscription, Int64.MaxValue);
-        }
+		{
+			var subscription = new AtomicReadModelSubscription<TModel>(_commitEnhancer, readModel, cs => false);
+			return _persistence.ReadForwardAsync(readModel.Id, readModel.AggregateVersion + 1, subscription, Int64.MaxValue);
+		}
 
 		/// <inheritdoc/>
 		public async Task<TModel> ProcessAsyncUntilUtcTimestamp<TModel>(string id, DateTime dateTimeUpTo) where TModel : IAtomicReadModel
-        {
-            var readmodel = _atomicReadModelFactory.Create<TModel>(id);
-            var subscription = new AtomicReadModelSubscription<TModel>(_commitEnhancer, readmodel, cs => cs.GetTimestamp() > dateTimeUpTo);
-            await _persistence.ReadForwardAsync(id, 0, subscription, Int64.MaxValue).ConfigureAwait(false);
-            return readmodel.AggregateVersion == 0 ? default : readmodel;
-        }
+		{
+			var readmodel = _atomicReadModelFactory.Create<TModel>(id);
+			var subscription = new AtomicReadModelSubscription<TModel>(_commitEnhancer, readmodel, cs => cs.GetTimestamp() > dateTimeUpTo);
+			await _persistence.ReadForwardAsync(id, 0, subscription, Int64.MaxValue).ConfigureAwait(false);
+			return readmodel.AggregateVersion == 0 ? default : readmodel;
+		}
+
+		public async Task<MultiStreamProcessorResult> ProcessAsync(IReadOnlyCollection<MultiStreamProcessRequest> request, long checkpointUpToIncluded)
+		{
+			if (request is null)
+			{
+				throw new ArgumentNullException(nameof(request));
+			}
+
+			//Need to prepare readmodel
+			IDictionary<string, IReadOnlyCollection<IAtomicReadModel>> rmDictionary = request.ToDictionary(
+				r => r.AggregateId,
+				r => r.ReadmodelTypes.Select(t => _atomicReadModelFactory.Create(t, r.AggregateId)).ToList() as IReadOnlyCollection<IAtomicReadModel>);
+
+			var subscription = new AtomicReadmodelMultiAggregateSubscription(_commitEnhancer, rmDictionary, cs => cs.GetChunkPosition() > checkpointUpToIncluded);
+			var idList = request.Select(r => r.AggregateId).ToList();
+			await _persistence.ReadForwardMultiplePartitionsAsync(idList, 0, subscription, checkpointUpToIncluded).ConfigureAwait(false);
+			return new MultiStreamProcessorResult(rmDictionary.Values);
+		}
+
+		public async Task<MultiStreamProcessorResult> ProcessAsync(IReadOnlyCollection<MultiStreamProcessRequest> request, DateTime dateTimeUpTo)
+		{
+			if (request is null)
+			{
+				throw new ArgumentNullException(nameof(request));
+			}
+
+			//Need to prepare readmodel
+			IDictionary<string, IReadOnlyCollection<IAtomicReadModel>> rmDictionary = request.ToDictionary(
+				r => r.AggregateId,
+				r => r.ReadmodelTypes.Select(t => _atomicReadModelFactory.Create(t, r.AggregateId)).ToList() as IReadOnlyCollection<IAtomicReadModel>);
+
+			var subscription = new AtomicReadmodelMultiAggregateSubscription(_commitEnhancer, rmDictionary, cs => cs.GetTimestamp() > dateTimeUpTo);
+			var idList = request.Select(r => r.AggregateId).ToList();
+			await _persistence.ReadForwardMultiplePartitionsAsync(idList, 0, subscription, Int32.MaxValue).ConfigureAwait(false);
+			return new MultiStreamProcessorResult(rmDictionary.Values);
+		}
 
 		/// <inheritdoc/>
 		public async Task<MultipleReadmodelProjectionResult> ProcessAsync(IEnumerable<Type> types, string id, long versionUpTo)
 		{
-            //Stop condition is version greater than the version we want to apply
-            List<IAtomicReadModel> readModels = types.Select(rmt => _atomicReadModelFactory.Create(rmt, id)).ToList();
+			//Stop condition is version greater than the version we want to apply
+			List<IAtomicReadModel> readModels = types.Select(rmt => _atomicReadModelFactory.Create(rmt, id)).ToList();
 			var subscription = new MultipleAtomicReadModelSubscription(_commitEnhancer, readModels, cs => cs.AggregateVersion > versionUpTo);
 			await _persistence.ReadForwardAsync(id, 0, subscription).ConfigureAwait(false);
-            return new MultipleReadmodelProjectionResult(readModels);
+			return new MultipleReadmodelProjectionResult(readModels);
 		}
 
 		/// <inheritdoc/>

--- a/Jarvis.Framework/ProjectionEngine/Atomic/Support/AtomicReadmodelEventConsumer.cs
+++ b/Jarvis.Framework/ProjectionEngine/Atomic/Support/AtomicReadmodelEventConsumer.cs
@@ -1,5 +1,6 @@
 ﻿using Castle.Core.Logging;
 using Jarvis.Framework.Shared.Events;
+using Jarvis.Framework.Shared.Exceptions;
 using Jarvis.Framework.Shared.IdentitySupport;
 using Jarvis.Framework.Shared.ReadModel.Atomic;
 using NStore.Domain;
@@ -75,6 +76,7 @@ namespace Jarvis.Framework.Kernel.ProjectionEngine.Atomic.Support
                     AtomicReadmodelInfoAttribute.Name,
                     changeset.Events?.OfType<DomainEvent>()?.FirstOrDefault()?.AggregateId ?? "Unknow aggregate id",
                     ex.Message);
+                //We mark aggregate as faulted with a special property that tells me is it is a framework exception.
                 rm.MarkAsFaulted(position);
                 readmodelModified = true;
                 //continue.


### PR DESCRIPTION
In this Pull requests we have two distinct increment
- Check on aggregate for error in projection
  - projecting wrong aggregate id
  - inverse order event dispatch
- Ability to project multiple aggregates with multiple readmodels.  