### PR TITLE
Refs: #56, Added IAtomicCollectionReaderQueryable interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# RCS1163: Unused parameter.
+dotnet_diagnostic.RCS1163.severity = none
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+
+# CS1574: XML comment has cref attribute that could not be resolved
+dotnet_diagnostic.CS1574.severity = none
+
+[*.xml]
+indent_style = space
+
+[*.cs]
+csharp_new_line_before_open_brace = all

--- a/Jarvis.Framework/ProjectionEngine/Atomic/IAtomicReadmodelCollectionWrapper.cs
+++ b/Jarvis.Framework/ProjectionEngine/Atomic/IAtomicReadmodelCollectionWrapper.cs
@@ -7,20 +7,29 @@ using System.Threading.Tasks;
 namespace Jarvis.Framework.Kernel.ProjectionEngine.Atomic
 {
     /// <summary>
+    /// Simple interface to expose <see cref="IQueryable{T}"/> interface,
+    /// so we can take advange of covariance in readmodels too.
+    /// </summary>
+    /// <typeparam name="TModel"></typeparam>
+    public interface IAtomicCollectionReaderQueryable<out TModel>
+        where TModel : IAtomicReadModel
+    {
+        /// <summary>
+        /// Allow standard IQueryable interface
+        /// </summary>
+        IQueryable<TModel> AsQueryable();
+    }
+
+    /// <summary>
     /// Simple wrapper for readmodel atomic collection. There is no need
     /// for corresponding reader, this is the only interface that will
     /// be used to access atomic readmodels, that are inherited by <see cref="AbstractAtomicReadModel"/>
     /// </summary>
     /// <typeparam name="TModel"></typeparam>
     public interface IAtomicCollectionReader<TModel>
-         where TModel : IAtomicReadModel
+        : IAtomicCollectionReaderQueryable<TModel>
+        where TModel : IAtomicReadModel
     {
-        /// <summary>
-        /// Allow standard IQueryable interface
-        /// </summary>
-        /// <returns></returns>
-        IQueryable<TModel> AsQueryable();
-
         /// <summary>
         /// Find a readmodel by id and does some checking like automatic rebuild
         /// of superseded readmodel, etc.

--- a/Wiki/ReleaseNotes.md
+++ b/Wiki/ReleaseNotes.md
@@ -1,6 +1,9 @@
 # J.A.R.V.I.S. Framework - Proximo srl (c)
 
-# vNext
+# 6.6.1
+
+- added IAtomicCollectionReaderQueryable (covariant reading interface), IAtomicCollectionReader inherits from IAtomicCollectionReaderQueryable [#56](https://github.com/ProximoSrl/Jarvis.Framework/issues/56)
+- added .editorconfig to configure development environments
 
 # 6.6.0
 


### PR DESCRIPTION
We needed an interface that support covariance when reading collection data.

We extracted a new interface from IAtomicCollectionReader interface that exposed the AsQueryable() property (because IQueryable<out T> was the only return value that could support covariance in the original interface).
