### PR TITLE
Added time to live for tracked messages in mongodb.

### DIFF
--- a/Jarvis.Framework.Shared/Commands/Tracking/TrackedMessageModel.cs
+++ b/Jarvis.Framework.Shared/Commands/Tracking/TrackedMessageModel.cs
@@ -14,6 +14,12 @@ namespace Jarvis.Framework.Shared.Commands.Tracking
         public string MessageId { get; set; }
 
         /// <summary>
+        /// If present indicates when the message will expire and will be deleted by the
+        /// mongodb database. Until the value is null mongod will not evict the message.
+        /// </summary>
+        public DateTime? ExpireDate { get; set; }
+
+        /// <summary>
         /// This is populated only if the command is an instance
         /// of <see cref="Command{TIdentity}"/>, in all other situation 
         /// is null.

--- a/Wiki/ReleaseNotes.md
+++ b/Wiki/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # J.A.R.V.I.S. Framework - Proximo srl (c)
 
+## vNext
+
+- Added time to live for TrackedMessageModel.
+
 # 6.6.2
 
 - Fixed out of order check for abstract atomic readmodel for deserialized readmodels.


### PR DESCRIPTION
Actually we have log-messages collection that grows indefintely and have really not useful information.
Type 0 and 2 are events and notifications, it can be useful for diagnose problems in events dispatching or notification dispatching but there are other methods than looking in that collection.

Type 1 are commands sent into the system, while it is interesting, successful commands are stored in event commit headers, only failed commands have really the need to be in this collection.

This commit implements a Time to Live field that keeps collection at bay.

Implements azdo internal tracker #11915