### PR TITLE
Better handling of aggregateversion and position for atomic

### DIFF
--- a/Jarvis.Framework.Shared/ReadModel/Atomic/AbstractAtomicReadModel.cs
+++ b/Jarvis.Framework.Shared/ReadModel/Atomic/AbstractAtomicReadModel.cs
@@ -63,6 +63,8 @@ namespace Jarvis.Framework.Shared.ReadModel.Atomic
         /// <summary>
         /// This is the Position of the last chunk. All <see cref="NStore.Domain.Changeset"/> are projected
         /// all events in a row. We do not save readmodel until all events of changeset are processed.
+        /// IMPORTANT: AFTER VERSION 7.4 even if readmodel process a changeset that does not contains event
+        /// that changed the readmodel this property is updated.
         /// </summary>
         public Int64 ProjectedPosition { get; private set; }
 
@@ -88,13 +90,7 @@ namespace Jarvis.Framework.Shared.ReadModel.Atomic
         /// </summary>
         public const int MaxNumberOfVersionToKeep = 20;
 
-        /// <summary>
-        /// To avoid creating error in projection where we have version 2 and 3 and for some reason we
-        /// dispatch version 3 before the 2, we keep a list of all version processed. This is done because
-        /// we can admit holes, so if the aggregate is in version X we can tolerate processing X+2 version
-        /// but if later X+1 is processed we have a problem and need to throw signaling that the aggregate
-        /// is faulted due to a wrong ordering.
-        /// </summary>
+        /// <inheritdoc />
         public List<long> LastProcessedVersions
         {
             get => _lastProcessedVersions ?? (_lastProcessedVersions = new List<long>());
@@ -103,6 +99,9 @@ namespace Jarvis.Framework.Shared.ReadModel.Atomic
 
         /// <summary>
         /// Version of the aggregate
+        /// IMPORTANT: AFTER VERSION 7.4 even if readmodel process a changeset that does not contains event
+        /// that changed the readmodel this property is updated.
+        /// Before 7.4 this property was updated only if the readmodel was really changed by the changeset.
         /// </summary>
         public Int64 AggregateVersion { get; private set; }
 

--- a/Jarvis.Framework.Shared/ReadModel/Atomic/IAtomicReadModel.cs
+++ b/Jarvis.Framework.Shared/ReadModel/Atomic/IAtomicReadModel.cs
@@ -1,5 +1,6 @@
 ﻿using NStore.Domain;
 using System;
+using System.Collections.Generic;
 
 namespace Jarvis.Framework.Shared.ReadModel.Atomic
 {
@@ -50,11 +51,20 @@ namespace Jarvis.Framework.Shared.ReadModel.Atomic
 		/// </summary>
 		Boolean ModifiedWithExtraStreamEvents { get; }
 
-		/// <summary>
-		/// Mark the readmodel as faulted.
-		/// </summary>
-		/// <param name="projectedPosition">Position that caused failure</param>
-		void MarkAsFaulted(Int64 projectedPosition);
+        /// <summary>
+        /// To avoid creating error in projection where we have version 2 and 3 and for some reason we
+        /// dispatch version 3 before the 2, we keep a list of all version processed. This is done because
+        /// we can admit holes, so if the aggregate is in version X we can tolerate processing X+2 version
+        /// but if later X+1 is processed we have a problem and need to throw signaling that the aggregate
+        /// is faulted due to a wrong ordering.
+        /// </summary>
+        List<long> LastProcessedVersions { get; }
+
+        /// <summary>
+        /// Mark the readmodel as faulted.
+        /// </summary>
+        /// <param name="projectedPosition">Position that caused failure</param>
+        void MarkAsFaulted(Int64 projectedPosition);
 
 		/// <summary>
 		/// A readmodel atomic is capable of processing events.

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/AtomicProjectionEngineTestBase.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/AtomicProjectionEngineTestBase.cs
@@ -282,12 +282,15 @@ namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic
             return cs;
         }
 
-        protected AtomicProjectionCheckpointManager GetTrackerAndWaitForChangesetToBeProjected(String readmodelName, Int64? positionToCheck = null)
+        protected AtomicProjectionCheckpointManager GetTrackerAndWaitForChangesetToBeProjected(
+            String readmodelName,
+            Int64? positionToCheck = null,
+            int waitTimeInSeconds = WaitTimeInSeconds)
         {
             var tracker = _container.Resolve<AtomicProjectionCheckpointManager>();
             positionToCheck = positionToCheck ?? lastUsedPosition;
             DateTime startWait = DateTime.UtcNow;
-            while (DateTime.UtcNow.Subtract(startWait).TotalSeconds < WaitTimeInSeconds
+            while (DateTime.UtcNow.Subtract(startWait).TotalSeconds < waitTimeInSeconds
                 && tracker.GetCheckpoint(readmodelName) < positionToCheck)
             {
                 Thread.Sleep(100);

--- a/Jarvis.Framework.Tests/ProjectionsTests/Atomic/Support/SimpleTestAtomicReadModel.cs
+++ b/Jarvis.Framework.Tests/ProjectionsTests/Atomic/Support/SimpleTestAtomicReadModel.cs
@@ -72,7 +72,7 @@ namespace Jarvis.Framework.Tests.ProjectionsTests.Atomic.Support
 		public static bool GenerateInternalExceptionforMaxTouch { get; set; }
 	}
 
-	public class SimpleTestAtomicReadModelInitializer : IAtomicReadModelInitializer
+    public class SimpleTestAtomicReadModelInitializer : IAtomicReadModelInitializer
 	{
 		private readonly IAtomicCollectionWrapper<SimpleTestAtomicReadModel> _atomicCollectionWrapper;
 

--- a/Jarvis.Framework/ProjectionEngine/Atomic/IAtomicReadmodelCollectionWrapper.cs
+++ b/Jarvis.Framework/ProjectionEngine/Atomic/IAtomicReadmodelCollectionWrapper.cs
@@ -128,5 +128,25 @@ namespace Jarvis.Framework.Kernel.ProjectionEngine.Atomic
         /// <remarks>If the readmodel is not present on database, nothing will be written.</remarks>
         /// <returns></returns>
         Task UpdateAsync(TModel model);
+
+        /// <summary>
+        /// <para>
+        /// Used in the following scenario.
+        /// I have a readmodel in version X = 6
+        /// Changeset 7 and 8 are applied but the readmodel does not handle events in those changeset
+        /// Usually projection service will not update the readmodel on Storage because it is not changed by the
+        /// events in the changeset.
+        /// Problem: Aggregate on disk is on AggregateVersion=6 and events 7 and 8 are not in the list of handled commits.
+        /// This generates lots of problem because it made almost impossible to diagnose errors.
+        /// </para>
+        /// <para>
+        /// Possible solution: Alwasy save the readmodel even if it declare that events does not change it.
+        /// Best solution: Call this method that will update only the relevant properties of the changes that will indicates
+        /// the real list of <see cref="Changeset"/> applied.
+        /// </para>
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns></returns>
+        Task UpdateVersionAsync(TModel model);
     }
 }

--- a/Jarvis.Framework/ProjectionEngine/Atomic/Support/AtomicReadmodelEventConsumer.cs
+++ b/Jarvis.Framework/ProjectionEngine/Atomic/Support/AtomicReadmodelEventConsumer.cs
@@ -94,6 +94,11 @@ namespace Jarvis.Framework.Kernel.ProjectionEngine.Atomic.Support
                 }
                 return new AtomicReadmodelChangesetConsumerReturnValue(rm, readmodelCreated);
             }
+            else
+            {
+                //readmodel was not modified, I want only to update some key information so position and aggregate version is update correctly
+                await _atomicCollectionWrapper.UpdateVersionAsync(rm).ConfigureAwait(false);
+            }
             return null;
         }
 

--- a/Wiki/ReleaseNotes.md
+++ b/Wiki/ReleaseNotes.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+  - Atomic readmodel now are updated in version and position even if changeset contains events that does not change the readmodel.
+
 ## 7.3.4
 
 - Small fixes for adding object serializer.


### PR DESCRIPTION
Before this modification on mongodb the aggregateVersion and Position of atomic readmodel were NOT updated if Changeset does not contains events that are processed by readmodel.

This commit introduces an efficient update of those version during projection to better troubleshooting.