### PR TITLE
Fix bugs of IdentityManager, added try get tag

### DIFF
--- a/Jarvis.Framework.Shared/IdentitySupport/IIdentityConverter.cs
+++ b/Jarvis.Framework.Shared/IdentitySupport/IIdentityConverter.cs
@@ -1,10 +1,40 @@
 ﻿namespace Jarvis.Framework.Shared.IdentitySupport
 {
+    /// <summary>
+    /// This interface is used to convert identity to string and viceversa.
+    /// </summary>
     public interface IIdentityConverter
     {
         string ToString(IIdentity identity);
         IIdentity ToIdentity(string identityAsString);
-        TIdentity ToIdentity<TIdentity>(string identityAsString);
-        bool TryParse<T>(string id, out T typedIdentity) where T : class, IIdentity;
+        TIdentity ToIdentity<TIdentity>(string identityAsString) where TIdentity : IIdentity;
+
+        /// <summary>
+        /// Try parsing a string to a specific identity, this method is used to avoid
+        /// throwing exception when parsing identity.
+        /// </summary>
+        /// <typeparam name="T">Type you want to check, it can be the <see cref="IIdentity"/> base interface
+        /// if you want to parse in any of known id, or you can pass concrete class to verify that the id
+        /// is indeed of the current type and parse at the same time.</typeparam>
+        /// <param name="id"></param>
+        /// <param name="typedIdentity"></param>
+        /// <returns></returns>
+        bool TryParse<T>(string id, out T typedIdentity) where T : IIdentity;
+
+        /// <summary>
+        /// <para>
+        /// Try to get the tag for a specific identity, this method is created to do a
+        /// fast check if <paramref name="id"/> is a valid identity registerd in
+        /// <see cref="IdentityManager"/>.
+        /// </para>
+        /// <para>
+        /// Needed to quick understand if a string is a valid identity without creating
+        /// a real identity and without using try/catch slow logic
+        /// </para>
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="tag"></param>
+        /// <returns></returns>
+        bool TryGetTag(string id, out string tag);
     }
 }

--- a/Jarvis.Framework.Shared/IdentitySupport/IIdentityGenerator.cs
+++ b/Jarvis.Framework.Shared/IdentitySupport/IIdentityGenerator.cs
@@ -14,13 +14,13 @@ namespace Jarvis.Framework.Shared.IdentitySupport
         /// </summary>
         /// <typeparam name="TIdentity">Type of the identity to generate.</typeparam>
         /// <returns>The newly generated identity</returns>
-        TIdentity New<TIdentity>();
+        TIdentity New<TIdentity>() where TIdentity : IIdentity;
 
         /// <summary>
         /// Generate the next identity for a given type.
         /// </summary>
         /// <typeparam name="TIdentity">Type of the identity to generate.</typeparam>
         /// <returns>The newly generated identity</returns>
-        Task<TIdentity> NewAsync<TIdentity>();
+        Task<TIdentity> NewAsync<TIdentity>() where TIdentity : IIdentity;
     }
 }

--- a/Jarvis.Framework.Tests/SharedTests/IdentitySupport/IdentityManagerTests.cs
+++ b/Jarvis.Framework.Tests/SharedTests/IdentitySupport/IdentityManagerTests.cs
@@ -99,5 +99,129 @@ namespace Jarvis.Framework.Tests.SharedTests.IdentitySupport
             Assert.ThrowsAsync<JarvisFrameworkEngineException>(
                 async () => await sut.ForceNextIdAsync<TestId>(nextId.Id));
         }
+
+        [TestCase("Test_1", true, 1)]
+        [TestCase("Test_2", true, 2)]
+        [TestCase("Test_9223372036854775808", false, 2)]
+        [TestCase("Test_9223372036854775807", true, 9223372036854775807L)]
+        [TestCase("Test_banana", false, 0)]
+        [TestCase("_2", false, 0)]
+        public void Verify_to_identity(string id, bool expected, long expectedId)
+        {
+            IIdentity result = null;
+            try
+            {
+                result = sut.ToIdentity(id);
+                if (!expected)
+                {
+                    Assert.Fail("Expected exception for invalid identity");
+                }
+            }
+            catch (Exception)
+            {
+                if (expected)
+                {
+                    Assert.Fail("Unexpected exception for valid identity");
+                }
+            }
+
+            if (expected)
+            {
+                Assert.That(result, Is.EqualTo(new TestId(expectedId)));
+            }
+        }
+
+        [TestCase("Test_1", true, 1)]
+        [TestCase("Test_2", true, 2)]
+        [TestCase("Test_9223372036854775808", false, 2)]
+        [TestCase("Test_9223372036854775807", true, 9223372036854775807L)]
+        [TestCase("Test_banana", false, 0)]
+        [TestCase("_2", false, 0)]
+        public void Verify_to_identity_typed(string id, bool expected, long expectedId)
+        {
+            IIdentity result = null;
+            try
+            {
+                result = sut.ToIdentity<TestId>(id);
+                if (!expected)
+                {
+                    Assert.Fail("Expected exception for invalid identity");
+                }
+            }
+            catch (Exception)
+            {
+                if (expected)
+                {
+                    Assert.Fail("Unexpected exception for valid identity");
+                }
+            }
+
+            if (expected)
+            {
+                Assert.That(result, Is.EqualTo(new TestId(expectedId)));
+            }
+        }
+
+        [Test]
+        public void Verify_to_identity_typed_with_wrong_type()
+        {
+            IIdentity result = null;
+            Assert.Throws<JarvisFrameworkIdentityException>(() => result = sut.ToIdentity<TestFlatId>("Test_123"));
+        }
+
+        [TestCase("Test_1", true, 1)]
+        [TestCase("Test_2", true, 2)]
+        [TestCase("Test_9223372036854775808", false, 2)]
+        [TestCase("Test_9223372036854775807", true, 9223372036854775807L)]
+        [TestCase("Test_banana", false, 0)]
+        [TestCase("_2", false, 0)]
+        [TestCase("", false, 0)]
+        [TestCase(null, false, 0)]
+        public void Verify_try_parse(string id, bool expected, long expectedId)
+        {
+            var result = sut.TryParse(id, out TestId typedIdentity);
+            Assert.That(result, Is.EqualTo(expected));
+            if (expected)
+            {
+                Assert.That(typedIdentity, Is.EqualTo(new TestId(expectedId)));
+            }
+        }
+
+        /// <summary>
+        /// Verify that we can parse an identity using the base interface
+        /// </summary>
+        [Test]
+        public void Verify_try_parse_with_base_interface()
+        {
+            var result = sut.TryParse<IIdentity>("Test_234", out var typedIdentity);
+            Assert.That(result, Is.True);
+            Assert.That(typedIdentity, Is.EqualTo(new TestId("Test_234")));
+        }
+
+        [Test]
+        public void Verify_try_parse_with_different_id()
+        {
+            var result = sut.TryParse<TestFlatId>("Test_234", out var typedIdentity);
+            Assert.That(result, Is.False);
+            Assert.That(typedIdentity, Is.EqualTo(null));
+        }
+
+        [TestCase("Test_1", true, "Test")]
+        [TestCase(null, false, "")]
+        [TestCase("", false, "")]
+        [TestCase("Test_2", true, "Test")]
+        [TestCase("Test_a2", false, "")]
+        [TestCase("Test_2a", false, "")]
+        [TestCase("Test_9223372036854775808", false, "")]
+        [TestCase("_1", false, "")]
+        [TestCase("Test_9223372036854775807", true, "Test")]
+        [TestCase("NotAnId_2", false, "")]
+        [TestCase("Test_banana", false, "")]
+        public void Verify_try_get_tag(string id, bool expected, string expectedTag)
+        {
+            var result = sut.TryGetTag(id, out string tag);
+            Assert.That(result, Is.EqualTo(expected));
+            Assert.That(tag, Is.EqualTo(expectedTag));
+        }
     }
 }

--- a/Wiki/ReleaseNotes.md
+++ b/Wiki/ReleaseNotes.md
@@ -2,6 +2,12 @@
 
 ## vNext
 
+- Added a TryGetTag for IIDentityTranslator also fixed some bugs.
+
+## 7.6.0
+
+- Updated nunit and mongodb driver.
+
 ## 7.5.1
 
 - Fixed dispatch of the process manager.


### PR DESCRIPTION
Fixed some problem with IDtranslator added TryGetTag for fast retrieval of the tag of the id, (useful when you need to cluster several id string with prefix)